### PR TITLE
fix(extension): fix search on MV3

### DIFF
--- a/build/app/public/js/base.js
+++ b/build/app/public/js/base.js
@@ -34395,7 +34395,6 @@ Search.prototype = _jquery["default"].extend({}, _view["default"].prototype, {
   _handleSubmit: function _handleSubmit(e) {
     e.preventDefault();
     this.model.doSearch(this.$input.val());
-    window.close();
   },
   _handleCogClick: function _handleCogClick(e) {
     e.preventDefault();

--- a/shared/js/ui/views/search.es6.js
+++ b/shared/js/ui/views/search.es6.js
@@ -52,7 +52,6 @@ Search.prototype = $.extend({}, Parent.prototype, {
     _handleSubmit: function (e) {
         e.preventDefault()
         this.model.doSearch(this.$input.val())
-        window.close()
     },
 
     _handleCogClick: function (e) {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:**
-->

## Description:

we were calling `window.close()` following a form submission which was causing some messages
to not be delivered to the service worker.

## Steps to test this PR:

1. Open the dashboard in the extension on MV3
2. Perform a search
3. It should always work (it was flaky before)
