### PR TITLE
fix(extensions): use chrome.i18n for language selection

### DIFF
--- a/build/app/public/js/base.js
+++ b/build/app/public/js/base.js
@@ -31172,11 +31172,26 @@ var resources = localeResources.reduce(function (mapping, _ref) {
   mapping[locale][namespace] = module;
   return mapping;
 }, {});
+function getDefaultLocale() {
+  // default to browser locale
+  var locale = 'en';
+
+  // prefer i18n.getUILanguage() if it exists
+  if (typeof chrome !== 'undefined') {
+    var _chrome$i18n;
+    var extensionLang = (_chrome$i18n = chrome.i18n) === null || _chrome$i18n === void 0 ? void 0 : _chrome$i18n.getUILanguage();
+    if (extensionLang) {
+      locale = extensionLang;
+    }
+  }
+  return locale.split('-')[0]; // drop country suffix
+}
+
 _i18next["default"].use(_i18nextIcu["default"]).init({
   // debug: true,
   initImmediate: false,
   fallbackLng: 'en',
-  lng: 'en',
+  lng: getDefaultLocale(),
   ns: ['shared', 'site', 'connection', 'report'],
   defaultNS: 'shared',
   resources: resources,

--- a/integration-tests/DashboardPage.js
+++ b/integration-tests/DashboardPage.js
@@ -146,11 +146,12 @@ export class DashboardPage {
      * @param {{
      *     getPrivacyDashboardData?: import('../schema/__generated__/schema.types').GetPrivacyDashboardData,
      * }} messages
+     * @param {string} locale
      * @returns {Promise<DashboardPage>}
      */
-    static async browser(page, messages) {
+    static async browser(page, messages, locale = 'en') {
         const dash = new DashboardPage(page, { name: 'browser' })
-        await dash.withMocks()
+        await dash.withMocks({ locale })
         await page.addInitScript((messages) => {
             window.__playwright.messages = Object.assign(window.__playwright.messages, messages)
         }, messages)
@@ -167,8 +168,13 @@ export class DashboardPage {
         return dash
     }
 
-    async withMocks() {
-        await this.mocks.install()
+    /**
+     * @param {Object} [opts]
+     * @param {string} [opts.locale]
+     * @returns {Promise<DashboardPage>}
+     */
+    async withMocks(opts) {
+        await this.mocks.install(opts)
         return this
     }
 

--- a/integration-tests/Mocks.js
+++ b/integration-tests/Mocks.js
@@ -13,7 +13,12 @@ export class Mocks {
         this.platform = platform
     }
 
-    async install() {
+    /**
+     * @param {Object} [opts]
+     * @param {string} [opts.locale]
+     * @returns {Promise<void|*|string>}
+     */
+    async install(opts) {
         switch (this.platform.name) {
             case 'android':
                 return installAndroidMocks(this.page)
@@ -25,7 +30,7 @@ export class Mocks {
             case 'example':
                 return '/build/app/html/example.html'
             case 'browser':
-                return installBrowserMocks(this.page)
+                return installBrowserMocks(this.page, opts)
             default: {
                 /** @type {never} */
                 const n = this.platform.name

--- a/integration-tests/browser.spec-int.js
+++ b/integration-tests/browser.spec-int.js
@@ -132,6 +132,15 @@ test.describe('tab data error', () => {
     })
 })
 
+test.describe('localization', () => {
+    test('should load with `pl` locale', async ({ page }) => {
+        const mock = new MockData({ url: 'https://example.com' })
+        const messages = mockToExtensionDashboardMessage(mock)
+        const dash = await DashboardPage.browser(page, messages, 'pl')
+        await dash.hasPolishLinkTextForConnectionInfo()
+    })
+})
+
 if (!process.env.CI) {
     const states = [
         { name: 'ad-attribution', state: dataStates['ad-attribution'] },

--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -253,10 +253,12 @@ export async function installWebkitMocks(page) {
 
 /**
  * @param {import("@playwright/test").Page} page
+ * @param {Object} [opts]
+ * @param {string} [opts.locale]
  * @returns {Promise<void>}
  */
-export async function installBrowserMocks(page) {
-    return page.addInitScript(() => {
+export async function installBrowserMocks(page, opts = { locale: 'en' }) {
+    return page.addInitScript((opts) => {
         const messages = {
             submitBrokenSiteReport: {},
             setLists: {},
@@ -276,6 +278,13 @@ export async function installBrowserMocks(page) {
                 },
                 calls: [],
                 listeners: [],
+            }
+
+            // @ts-ignore
+            window.chrome.i18n = {
+                getUILanguage() {
+                    return opts?.locale || 'en'
+                },
             }
 
             // override some methods on window.chrome.runtime to fake the incoming/outgoing messages
@@ -310,5 +319,5 @@ export async function installBrowserMocks(page) {
             console.error("❌couldn't set up browser mocks")
             console.error(e)
         }
-    })
+    }, opts)
 }

--- a/shared/js/ui/base/localize.es6.js
+++ b/shared/js/ui/base/localize.es6.js
@@ -13,11 +13,26 @@ const resources = localeResources.reduce((mapping, { name, module }) => {
     return mapping
 }, {})
 
+function getDefaultLocale() {
+    // default to browser locale
+    let locale = 'en'
+
+    // prefer i18n.getUILanguage() if it exists
+    if (typeof chrome !== 'undefined') {
+        const extensionLang = chrome.i18n?.getUILanguage()
+        if (extensionLang) {
+            locale = extensionLang
+        }
+    }
+
+    return locale.split('-')[0] // drop country suffix
+}
+
 i18next.use(ICU).init({
     // debug: true,
     initImmediate: false,
     fallbackLng: 'en',
-    lng: 'en',
+    lng: getDefaultLocale(),
     ns: ['shared', 'site', 'connection', 'report'],
     defaultNS: 'shared',
     resources,


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

https://app.asana.com/0/1200835453786799/1203485757983743/f

<!-- Optional fields
**CC:**
**Depends on:**
-->

## Description:

in our extensions, we were not using `chrome.i18n.getUILanguage()` to determine the correct browser UI language.

## Steps to test this PR:

- [x] integration test added 
