### PR TITLE
Hide port from domain in the dashboard.

### DIFF
--- a/build/app/public/js/base.js
+++ b/build/app/public/js/base.js
@@ -30449,7 +30449,7 @@ exports.TabData = TabData;
 var createTabData = function createTabData(tabUrl, upgradedHttps, protections, rawRequestData) {
   var domain;
   try {
-    domain = new URL(tabUrl).host.replace(/^www\./, '');
+    domain = new URL(tabUrl).hostname.replace(/^www\./, '');
   } catch (e) {
     domain = 'unknown';
   }

--- a/shared/js/browser/utils/__snapshots__/request-details.test.js.snap
+++ b/shared/js/browser/utils/__snapshots__/request-details.test.js.snap
@@ -86,3 +86,139 @@ AggregatedCompanyResponseData {
   "requestCount": 1,
 }
 `;
+
+exports[`createTabData creates a TabData object 1`] = `
+Object {
+  "certificate": undefined,
+  "cookiePromptManagementStatus": undefined,
+  "ctaScreens": undefined,
+  "domain": "example.com",
+  "emailProtection": undefined,
+  "error": undefined,
+  "id": undefined,
+  "isPendingUpdates": undefined,
+  "locale": null,
+  "parentEntity": undefined,
+  "permissions": undefined,
+  "platformLimitations": undefined,
+  "protections": Protections {
+    "allowlisted": false,
+    "denylisted": false,
+    "enabledFeatures": Array [],
+    "unprotectedTemporary": false,
+  },
+  "requestDetails": RequestDetails {
+    "all": AggregatedCompanyResponseData {
+      "entities": Object {},
+      "entitiesCount": 0,
+      "requestCount": 0,
+    },
+    "allowed": Object {
+      "adClickAttribution": AggregatedCompanyResponseData {
+        "entities": Object {},
+        "entitiesCount": 0,
+        "requestCount": 0,
+      },
+      "otherThirdPartyRequest": AggregatedCompanyResponseData {
+        "entities": Object {},
+        "entitiesCount": 0,
+        "requestCount": 0,
+      },
+      "ownedByFirstParty": AggregatedCompanyResponseData {
+        "entities": Object {},
+        "entitiesCount": 0,
+        "requestCount": 0,
+      },
+      "protectionDisabled": AggregatedCompanyResponseData {
+        "entities": Object {},
+        "entitiesCount": 0,
+        "requestCount": 0,
+      },
+      "ruleException": AggregatedCompanyResponseData {
+        "entities": Object {},
+        "entitiesCount": 0,
+        "requestCount": 0,
+      },
+    },
+    "blocked": AggregatedCompanyResponseData {
+      "entities": Object {},
+      "entitiesCount": 0,
+      "requestCount": 0,
+    },
+    "surrogates": Array [],
+  },
+  "search": undefined,
+  "specialDomainName": undefined,
+  "status": "complete",
+  "upgradedHttps": true,
+  "url": "https://www.example.com/",
+}
+`;
+
+exports[`createTabData removes port from the site domain 1`] = `
+Object {
+  "certificate": undefined,
+  "cookiePromptManagementStatus": undefined,
+  "ctaScreens": undefined,
+  "domain": "example.com",
+  "emailProtection": undefined,
+  "error": undefined,
+  "id": undefined,
+  "isPendingUpdates": undefined,
+  "locale": null,
+  "parentEntity": undefined,
+  "permissions": undefined,
+  "platformLimitations": undefined,
+  "protections": Protections {
+    "allowlisted": false,
+    "denylisted": false,
+    "enabledFeatures": Array [],
+    "unprotectedTemporary": false,
+  },
+  "requestDetails": RequestDetails {
+    "all": AggregatedCompanyResponseData {
+      "entities": Object {},
+      "entitiesCount": 0,
+      "requestCount": 0,
+    },
+    "allowed": Object {
+      "adClickAttribution": AggregatedCompanyResponseData {
+        "entities": Object {},
+        "entitiesCount": 0,
+        "requestCount": 0,
+      },
+      "otherThirdPartyRequest": AggregatedCompanyResponseData {
+        "entities": Object {},
+        "entitiesCount": 0,
+        "requestCount": 0,
+      },
+      "ownedByFirstParty": AggregatedCompanyResponseData {
+        "entities": Object {},
+        "entitiesCount": 0,
+        "requestCount": 0,
+      },
+      "protectionDisabled": AggregatedCompanyResponseData {
+        "entities": Object {},
+        "entitiesCount": 0,
+        "requestCount": 0,
+      },
+      "ruleException": AggregatedCompanyResponseData {
+        "entities": Object {},
+        "entitiesCount": 0,
+        "requestCount": 0,
+      },
+    },
+    "blocked": AggregatedCompanyResponseData {
+      "entities": Object {},
+      "entitiesCount": 0,
+      "requestCount": 0,
+    },
+    "surrogates": Array [],
+  },
+  "search": undefined,
+  "specialDomainName": undefined,
+  "status": "complete",
+  "upgradedHttps": true,
+  "url": "https://www.example.com:8080/",
+}
+`;

--- a/shared/js/browser/utils/request-details.js
+++ b/shared/js/browser/utils/request-details.js
@@ -99,7 +99,7 @@ export class TabData {
 export const createTabData = (tabUrl, upgradedHttps, protections, rawRequestData) => {
     let domain
     try {
-        domain = new URL(tabUrl).host.replace(/^www\./, '')
+        domain = new URL(tabUrl).hostname.replace(/^www\./, '')
     } catch (e) {
         domain = 'unknown'
     }

--- a/shared/js/browser/utils/request-details.test.js
+++ b/shared/js/browser/utils/request-details.test.js
@@ -1,7 +1,7 @@
 import amazon from '../../../../schema/__fixtures__/request-data-amazon.json'
 import google from '../../../../schema/__fixtures__/request-data-google.json'
 import cnn from '../../../../schema/__fixtures__/request-data-cnn.json'
-import { createRequestDetails, fromJson, fromMultiJson, states } from './request-details'
+import { createRequestDetails, createTabData, fromJson, fromMultiJson, Protections, states } from './request-details'
 
 describe('RequestDetails', () => {
     it('accepts zero requests', () => {
@@ -91,5 +91,19 @@ describe('RequestDetails', () => {
             ],
         })
         expect(requestDetails.all).toMatchSnapshot()
+    })
+})
+
+describe('createTabData', () => {
+    it('creates a TabData object', () => {
+        const url = 'https://www.example.com/'
+        const tabData = createTabData(url, true, new Protections(false, [], false, false), { requests: [] })
+        expect(tabData).toMatchSnapshot()
+    })
+
+    it('removes port from the site domain', () => {
+        const url = 'https://www.example.com:8080/'
+        const tabData = createTabData(url, true, new Protections(false, [], false, false), { requests: [] })
+        expect(tabData).toMatchSnapshot()
     })
 })


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @shakyShane 

<!-- Optional fields
**CC:**
**Depends on:**
-->

## Description:
Removes the port from the site's `domain`. This fixes a downstream issue in the extension where we expect allowlisted domains to be hostname only (i.e. without port).

## Steps to test this PR:

<!-- List steps to test it manually
1. <STEP 1>
-->
