### PR TITLE
Exclude font assets from Swift Package bundle

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,11 @@ let package = Package(
         .target(
             name: "PrivacyDashboard-resources",
             path: "build",
-            resources: [.copy("app")]),
+            exclude: ["app/font"], 
+            resources: [.copy ("app/html"),
+                        .copy("app/img"),
+                        .copy ("app/public"),
+                        .copy ("app/index.html")]),
 
         .testTarget(
             name: "PrivacyDashboardTests",

--- a/swift-package/Sources/Bundle.swift
+++ b/swift-package/Sources/Bundle.swift
@@ -5,9 +5,9 @@ import PrivacyDashboard_resources
 public extension Bundle {
     static var privacyDashboardURL: URL? {
         #if os(iOS)
-            privacyDashboardResourcesBundle.url(forResource: "ios", withExtension: "html", subdirectory: "app/html")
+            privacyDashboardResourcesBundle.url(forResource: "ios", withExtension: "html", subdirectory: "html")
         #elseif os(macOS)
-            privacyDashboardResourcesBundle.url(forResource: "macos", withExtension: "html", subdirectory: "app/html")
+            privacyDashboardResourcesBundle.url(forResource: "macos", withExtension: "html", subdirectory: "html")
         #else
             nil
         #endif


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana task:** https://app.asana.com/0/1200835453786799/1203532353505600/f
## Description:
Change how we bundle assets for Apple platforms. We want to exclude woff/woff2 font files from the bundle. To do so we add their path to exclude list but at the same time we need to specify subfolders and files that we want to include explicitly.
Additional we need to update the resource bundle path to html file as we no longer include the topmost 'app' folder. 

## Steps to test this PR:
1. Setup iOS and macOS clients using local BSK copy.
2. In BSK's Package.swift update the PD reference to: `.package(url: "https://github.com/duckduckgo/privacy-dashboard", .revision("fe3eb73718e20ba2c2e61d726fa93edddafbaacf"))`
3. Do a clean build of iOS and macOS to test if PD opens and works properly.
