### PR TITLE
Fix breakage form localization

### DIFF
--- a/build/app/public/js/base.js
+++ b/build/app/public/js/base.js
@@ -33026,32 +33026,32 @@ var _topNav = require("./shared/top-nav");
 var _templateObject, _templateObject2;
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 function _taggedTemplateLiteral(strings, raw) { if (!raw) { raw = strings.slice(0); } return Object.freeze(Object.defineProperties(strings, { raw: { value: Object.freeze(raw) } })); }
-var categories = [{
-  category: _localize.i18n.t('report:videos.title'),
-  value: 'videos'
-}, {
-  category: _localize.i18n.t('report:images.title'),
-  value: 'images'
-}, {
-  category: _localize.i18n.t('report:comments.title'),
-  value: 'comments'
-}, {
-  category: _localize.i18n.t('report:content.title'),
-  value: 'content'
-}, {
-  category: _localize.i18n.t('report:links.title'),
-  value: 'links'
-}, {
-  category: _localize.i18n.t('report:login.title'),
-  value: 'login'
-}, {
-  category: _localize.i18n.t('report:paywall.title'),
-  value: 'paywall'
-}, {
-  category: _localize.i18n.t('report:other.title'),
-  value: 'other'
-}];
 function _default() {
+  var categories = [{
+    category: _localize.i18n.t('report:videos.title'),
+    value: 'videos'
+  }, {
+    category: _localize.i18n.t('report:images.title'),
+    value: 'images'
+  }, {
+    category: _localize.i18n.t('report:comments.title'),
+    value: 'comments'
+  }, {
+    category: _localize.i18n.t('report:content.title'),
+    value: 'content'
+  }, {
+    category: _localize.i18n.t('report:links.title'),
+    value: 'links'
+  }, {
+    category: _localize.i18n.t('report:login.title'),
+    value: 'login'
+  }, {
+    category: _localize.i18n.t('report:paywall.title'),
+    value: 'paywall'
+  }, {
+    category: _localize.i18n.t('report:other.title'),
+    value: 'other'
+  }];
   var icon = (0, _heroEs.largeHeroIcon)({
     status: 'breakage-form'
   });

--- a/shared/js/ui/templates/breakage-form.es6.js
+++ b/shared/js/ui/templates/breakage-form.es6.js
@@ -3,18 +3,17 @@ import { i18n } from '../base/localize.es6'
 import { largeHeroIcon } from './shared/hero.es6.js'
 import { topNav } from './shared/top-nav'
 
-const categories = [
-    { category: i18n.t('report:videos.title'), value: 'videos' },
-    { category: i18n.t('report:images.title'), value: 'images' },
-    { category: i18n.t('report:comments.title'), value: 'comments' },
-    { category: i18n.t('report:content.title'), value: 'content' },
-    { category: i18n.t('report:links.title'), value: 'links' },
-    { category: i18n.t('report:login.title'), value: 'login' },
-    { category: i18n.t('report:paywall.title'), value: 'paywall' },
-    { category: i18n.t('report:other.title'), value: 'other' },
-]
-
 export default function () {
+    const categories = [
+        { category: i18n.t('report:videos.title'), value: 'videos' },
+        { category: i18n.t('report:images.title'), value: 'images' },
+        { category: i18n.t('report:comments.title'), value: 'comments' },
+        { category: i18n.t('report:content.title'), value: 'content' },
+        { category: i18n.t('report:links.title'), value: 'links' },
+        { category: i18n.t('report:login.title'), value: 'login' },
+        { category: i18n.t('report:paywall.title'), value: 'paywall' },
+        { category: i18n.t('report:other.title'), value: 'other' },
+    ]
     const icon = largeHeroIcon({
         status: 'breakage-form',
     })


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:**
-->

## Description:
The list of categories for the breakage form was being generated at script load time, at which point locales were not loaded yet. This meant that the category labels were always in English.

This PR moves this loading to render-time, which means that it should properly render in the current language.

## Steps to test this PR:

<!-- List steps to test it manually
1. <STEP 1>
-->
