### PR TITLE
Increase max-width of "Share DuckDuckGo" CTA button to fit all languages

### DIFF
--- a/build/app/public/css/popup.css
+++ b/build/app/public/css/popup.css
@@ -3090,7 +3090,7 @@ body.environment--macos, body.environment--browser, body.environment--windows, b
   background: var(--color-accent-blue);
   border-radius: 8px;
   padding: 10px 16px;
-  max-width: 165px;
+  max-width: 250px;
   font-style: normal;
   font-weight: 600;
   font-size: 13px;

--- a/shared/scss/views/_cta-screens.scss
+++ b/shared/scss/views/_cta-screens.scss
@@ -35,7 +35,7 @@
     background: var(--color-accent-blue);
     border-radius: 8px;
     padding: 10px 16px;
-    max-width: 165px;
+    max-width: 250px;
     font-style: normal;
     font-weight: 600;
     font-size: 13px;


### PR DESCRIPTION

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:**
-->

## Description:

The "Share DuckDuckGo" CTA button text was wrapping in some languages. This PR increases the max-width of this element so this always fits on one line:

Before:
![Screenshot 2023-05-04 at 10 27 27](https://user-images.githubusercontent.com/248111/236151183-2309ef95-6ac7-4a34-a221-8b09a370d3e3.png)

After:
![Screenshot 2023-05-04 at 10 26 50](https://user-images.githubusercontent.com/248111/236151214-89c9f56b-b0a4-43ef-a546-20837b7d5d17.png)

## Steps to test this PR:
 1. `npm run preview`
 2. Visit http://127.0.0.1:3210/html/popup.html?platform=browser&theme=light&specialDomainName=extensions&state=04&locale=lt
 3. Check that the text doesn't wrap.