### PR TITLE
esbuild: 2021 target to match C-S-S

### DIFF
--- a/build/app/public/js/base.js
+++ b/build/app/public/js/base.js
@@ -6,6 +6,7 @@
   var __getOwnPropNames = Object.getOwnPropertyNames;
   var __getProtoOf = Object.getPrototypeOf;
   var __hasOwnProp = Object.prototype.hasOwnProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
   var __esm = (fn, res) => function __init() {
     return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])(fn = 0)), res;
   };
@@ -33,6 +34,10 @@
     mod2
   ));
   var __toCommonJS = (mod2) => __copyProps(__defProp({}, "__esModule", { value: true }), mod2);
+  var __publicField = (obj, key, value) => {
+    __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+    return value;
+  };
 
   // node_modules/jquery/dist/jquery.js
   var require_jquery = __commonJS({
@@ -10775,12 +10780,14 @@
         };
       };
       AggregatedCompanyResponseData = class {
-        /** @type {number} */
-        entitiesCount = 0;
-        /** @type {number} */
-        requestCount = 0;
-        /** @type {Record<string, AggregateCompanyData>} */
-        entities = {};
+        constructor() {
+          /** @type {number} */
+          __publicField(this, "entitiesCount", 0);
+          /** @type {number} */
+          __publicField(this, "requestCount", 0);
+          /** @type {Record<string, AggregateCompanyData>} */
+          __publicField(this, "entities", {});
+        }
         /**
          * @param {import('../../../../schema/__generated__/schema.types.js').DetectedRequest} request
          */
@@ -10845,20 +10852,20 @@
         protectionsOff_allowedTrackers_allowedNonTrackers: "protectionsOff_allowedTrackers_allowedNonTrackers"
       };
       RequestDetails = class {
-        surrogates;
-        all = new AggregatedCompanyResponseData();
-        blocked = new AggregatedCompanyResponseData();
-        allowed = {
-          adClickAttribution: new AggregatedCompanyResponseData(),
-          ownedByFirstParty: new AggregatedCompanyResponseData(),
-          ruleException: new AggregatedCompanyResponseData(),
-          protectionDisabled: new AggregatedCompanyResponseData(),
-          otherThirdPartyRequest: new AggregatedCompanyResponseData()
-        };
         /**
          * @param {string[]} surrogates - any installed surrogates, just the domains
          */
         constructor(surrogates) {
+          __publicField(this, "surrogates");
+          __publicField(this, "all", new AggregatedCompanyResponseData());
+          __publicField(this, "blocked", new AggregatedCompanyResponseData());
+          __publicField(this, "allowed", {
+            adClickAttribution: new AggregatedCompanyResponseData(),
+            ownedByFirstParty: new AggregatedCompanyResponseData(),
+            ruleException: new AggregatedCompanyResponseData(),
+            protectionDisabled: new AggregatedCompanyResponseData(),
+            otherThirdPartyRequest: new AggregatedCompanyResponseData()
+          });
           this.surrogates = surrogates;
         }
         /**

--- a/scripts/bundle.mjs
+++ b/scripts/bundle.mjs
@@ -27,6 +27,7 @@ async function init() {
     await esbuild.build({
         entryPoints: [manifest.base.input],
         bundle: true,
+        target: ['es2021'],
         outfile: manifest.base.output,
         sourcemap: debug ? 'linked' : undefined,
         dropLabels: IS_PROD ? ['$TEST'] : [],
@@ -53,6 +54,7 @@ async function init() {
 
     await esbuild.build({
         entryPoints: [manifest.polyfills.input],
+        target: ['es2021'],
         bundle: true,
         outfile: manifest.polyfills.output,
         sourcemap: debug ? 'linked' : undefined,


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:**
-->

## Description:

- Just a safe-guard to match the build target we use in AutoConsent & C-S-S.
- I don't think this is technically needed, but before we push a large update to Android I'd rather be consistent with out JS bundles we produce :)


<!-- Explain what is being changed, why, etc -->

## Steps to test this PR:

<!-- List steps to test it manually
1. <STEP 1>
-->
