### PR TITLE
reflect params in the debugger

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "npm": ">=9.0.0"
     },
     "scripts": {
+        "start": "npm run dev",
         "dev": "chokidar \"shared\" 'debugger' \"schema/*.json\" -c \"npm run build.debug\" --initial \"npm run build.debug\"",
         "build.watch.prod": "chokidar \"shared\" \"schema/*.json\" -c \"npm run build\" --initial \"npm run build\"",
         "build": "node scripts/build.js",

--- a/shared/js/ui/views/tests/generate-data.mjs
+++ b/shared/js/ui/views/tests/generate-data.mjs
@@ -239,8 +239,10 @@ export class MockData {
      * @param {import('../../../../../schema/__generated__/schema.types').CookiePromptManagementStatus} [params.cookiePromptManagementStatus]
      * @param {import('../../../../../schema/__generated__/schema.types').RemoteFeatureSettings} [params.remoteFeatureSettings]
      * @param {import('../../../../../schema/__generated__/schema.types').EmailProtectionUserData} [params.emailProtectionUserData]
+     * @param {{screen?: import('../../../../../schema/__generated__/schema.types').ScreenKind}} [params.urlParams]
      */
     constructor(params) {
+        this.urlParams = params.urlParams || {}
         this.url = params.url || 'https://example.com'
         this.requests = params.requests || []
         this.state = params.state
@@ -706,6 +708,20 @@ export const createDataStates = (google, cnn) => {
             url: 'https://example.com',
             // @ts-expect-error - this SHOULD error, that's the test
             requests: [{ foo: 'bar' }],
+        }),
+        'screen-breakageForm': new MockData({
+            url: 'https://example.com',
+            requests: [],
+            urlParams: {
+                screen: 'breakageForm',
+            },
+        }),
+        'screen-toggleReport': new MockData({
+            url: 'https://example.com',
+            requests: [],
+            urlParams: {
+                screen: 'toggleReport',
+            },
         }),
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
         "jsxFactory": "h",
         "jsxFragmentFactory": "Fragment"
     },
-    "include": ["types.ts", "schema", "e2e", "scripts", "shared/js", "integration-tests", "guides"]
+    "include": ["types.ts", "schema", "e2e", "scripts", "shared/js", "integration-tests", "guides", "debugger"]
 }

--- a/types.ts
+++ b/types.ts
@@ -84,3 +84,8 @@ interface WebkitMessageHandlers {
         postMessage: (params: any) => Promise<void>
     }
 }
+
+declare module '*.css' {
+    const classMap: Record<string, any>
+    export default classMap
+}


### PR DESCRIPTION
https://app.asana.com/0/0/1207195637811329/f

### TL;DR

Update debugger to reflect url parameters and fix initial state loading. This will be needed in the next PR to preview/debug another new screen.

### What changed?

- Updated debugger to reflect url parameters
- Fixed initial state loading

### How to test?

- Verify URL parameters are reflected correctly
  - `npm run preview`
  - then select one of the new options in the select menu 
     - `screen-breakageForm`, or
     - `screen-toggleReport`
  - if the iframe previews load as they do in the video, then all is good :)


<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/Youbs18YwblmJpLrzsDC/395525a1-ddee-4001-8c2d-26803c604b91.mp4">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/Youbs18YwblmJpLrzsDC/395525a1-ddee-4001-8c2d-26803c604b91.mp4">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/Youbs18YwblmJpLrzsDC/395525a1-ddee-4001-8c2d-26803c604b91.mp4">ScreenFlow.mp4</video>

### Why make this change?

This change ensures the debugger reflects correct URL parameters - to mimic what the native applications do. Without this change, you could not load the dashboard in this state,  making debugging more difficult
