### PR TITLE
fixed debug deployment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
             - name: Build docs
               run: npm run docs
             - name: copy-to-docs
-              run: cp -r build/app/ build/docs/app
+              run: cp -r build/app-debug/ build/docs/app-debug
     deploy:
         runs-on: ubuntu-20.04
         needs: build


### PR DESCRIPTION
### TL;DR

This pull request changes the directory in the `copy-to-docs` command in the tests workflow.

### What changed?

In our GitHub Actions' tests workflow, we've changed the `copy-to-docs` step. Specifically, it now copies from `build/app-debug/` instead of `build/app/`.

### How to test?

Once the PR is merged, the dashboard should be accessible  at https://duckduckgo.github.io/privacy-dashboard/app-debug <- this is important to be the debug build because it uses mocked communications.

### Why make this change?

Required to view the dashboard via the docs

