### PR TITLE
use playwright tags to separate screenshots

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,8 @@ jobs:
               with:
                   path: build/docs
                   key: build-output-${{ github.run_id }}
+            - name: Fetch fonts
+              run: npm run fetch-fonts
             - name: Build all
               run: npm run build && npm run build.debug
             ###

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,10 +62,10 @@ jobs:
               with:
                   path: build/docs
                   key: build-output-${{ github.run_id }}
-            - name: Fetch fonts
-              run: npm run fetch-fonts
             - name: Build all
               run: npm run build && npm run build.debug
+            - name: Fetch fonts
+              run: npm run fetch-fonts
             ###
             ###  Run clean-tree following the build - no changes should be present
             ###

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,8 +71,10 @@ jobs:
               run: npm run test.clean-tree
             - name: Install Playwright Browsers
               run: npx playwright install --with-deps
-            - name: Run Playwright (integration) tests
-              run: npm run test.int
+            - name: Run Playwright tests (none-screenshots)
+              run: npm run test.int -- --grep-invert @screenshots
+            - name: Run Playwright tests (screenshots only)
+              run: npm run test.int -- --grep @screenshots
             - uses: actions/upload-artifact@v3
               if: always()
               with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Clicking any of the 'open in new tab' links will open the application in dedicat
 
 -   emulating dark/light mode
     -   use the dev tools 'emulate dark/light mode'
--   emulating tracker states, allowlisting andmore
+-   emulating tracker states, allowlisting and more
     -   use the select in the header to choose a state
 
 ## Browser/Extension specific overrides
@@ -109,5 +109,7 @@ Test files can be found co-located with the corresponding code using `.test.js` 
 To verify the platform-specific communications, run the integration tests
 
 -   Run `npm run test.int` to have all platforms tested
--   Run `npm run test.int --project ios` to only run the iOS tests - likewise for the other platforms
+-   Run `npm run test.int --project ios` to only run the iOS tests, likewise for the other platforms
+-   Run `npm run test.int -- --grep @screenshots` to only run screenshot tests
+-   Run `npm run test.int -- --grep-invert @screenshots` to only run non-screenshot tests
 -   Run `npm run test.int.update-screenshots` to also update screenshots (if you've made changes to anything visual)

--- a/build/app/public/js/base.js
+++ b/build/app/public/js/base.js
@@ -14887,7 +14887,9 @@
   function useFetcher() {
     return T2(async (msg) => {
       try {
-        console.log("\u{1F4E4} [outgoing useFetcher]", msg);
+        if (!window.__ddg_integration_test) {
+          console.log("\u{1F4E4} [outgoing useFetcher]", msg);
+        }
         return communication_default.fetch(msg);
       } catch (error2) {
         console.error("Error:", error2);
@@ -15208,7 +15210,6 @@
       while (instances.length) {
         const last = instances.pop();
         last.destroy();
-        console.log("destroy");
       }
     };
   }
@@ -17260,7 +17261,9 @@
     return canPopFrom(screen);
   }
   function navReducer(state, event) {
-    console.log("\u{1F4E9}", event, state);
+    if (!window.__ddg_integration_test) {
+      console.log("\u{1F4E9}", event, state);
+    }
     switch (state.state) {
       case "transitioning": {
         switch (event.type) {

--- a/integration-tests/DashboardPage.js
+++ b/integration-tests/DashboardPage.js
@@ -56,26 +56,12 @@ export class DashboardPage {
         await this.page.getByTestId('protectionHeader').waitFor({ timeout: 1000 })
     }
 
-    async showsTogglePrompt() {
-        await this.page.getByRole('link', { name: 'Website not working?' }).waitFor({ timeout: 1000 })
-    }
-
     async screenshot(name) {
-        if (!process.env.CI) {
-            // console.log('🚧 skipping screenshot 🚧', name)
-            await expect(this.page).toHaveScreenshot(name, { maxDiffPixelRatio: 0.025 })
-        }
+        await expect(this.page).toHaveScreenshot(name, { maxDiffPixelRatio: 0.025 })
     }
 
     async reducedMotion() {
         await this.page.emulateMedia({ reducedMotion: 'reduce' })
-    }
-
-    async screenshotPrimary(name, state) {
-        await this.reducedMotion()
-        await this.addState([state])
-        await this.showsPrimaryScreen()
-        return this.page.screenshot({ path: `screenshots/primary-${name}.png` })
     }
 
     /**

--- a/integration-tests/android.spec-int.js
+++ b/integration-tests/android.spec-int.js
@@ -12,7 +12,7 @@ test.describe('initial page data', () => {
 })
 
 test.describe('page data (with trackers)', () => {
-    test('should display correct primary screen', async ({ page }) => {
+    test('should display correct primary screen', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await DashboardPage.android(page)
         await dash.addState([testDataStates.cnn])
         await dash.showsPrimaryScreen()
@@ -25,6 +25,7 @@ test.describe('page data (with trackers)', () => {
         await dash.aboutLinkHasRipple()
     })
 })
+
 test.describe('open external links', () => {
     test('should call android interface for links', async ({ page }) => {
         const dash = await DashboardPage.android(page)
@@ -101,8 +102,8 @@ test.describe('cookie prompt management', () => {
     })
 })
 
-if (!process.env.CI) {
-    test.describe('screenshots', () => {
+test.describe('Android screenshots', { tag: '@screenshots' }, () => {
+    test.describe('states', () => {
         const states = [
             { name: 'ad-attribution', state: testDataStates['ad-attribution'] },
             { name: 'new-entities', state: testDataStates['new-entities'] },
@@ -117,6 +118,7 @@ if (!process.env.CI) {
             })
         }
     })
+
     test.describe('screenshots for alternative layout states', () => {
         const states = [
             { name: 'alternative-layout-exp-1', state: testDataStates['alternative-layout-exp-1'] },
@@ -132,6 +134,7 @@ if (!process.env.CI) {
             })
         }
     })
+
     test.describe('screenshots for cookies (non-configurable)', () => {
         test('primary screen', async ({ page }) => {
             const dash = await DashboardPage.android(page)
@@ -140,6 +143,7 @@ if (!process.env.CI) {
             await dash.screenshot('consent-managed.png')
         })
     })
+
     test.describe('screenshots for cookies (configurable)', () => {
         test.describe('non-cosmetic', () => {
             test('primary screen', async ({ page }) => {
@@ -174,4 +178,4 @@ if (!process.env.CI) {
             })
         })
     })
-}
+})

--- a/integration-tests/browser.spec-int.js
+++ b/integration-tests/browser.spec-int.js
@@ -122,7 +122,7 @@ test.describe('fire button', () => {
     })
 })
 
-test.describe('screenshots', () => {
+test.describe('screenshots', { tag: '@screenshots' }, () => {
     const states = [
         { name: 'ad-attribution', state: testDataStates['ad-attribution'] },
         { name: 'new-entities', state: testDataStates['new-entities'] },

--- a/integration-tests/ios.spec-int.js
+++ b/integration-tests/ios.spec-int.js
@@ -9,7 +9,7 @@ test.describe('page data (no trackers)', () => {
         await dash.addState([testDataStates.protectionsOn])
         await dash.showsPrimaryScreen()
     })
-    test('should accept updates when on trackers list screen', async ({ page }) => {
+    test('should accept updates when on trackers list screen', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await DashboardPage.webkit(page)
         await dash.addState([testDataStates.protectionsOn])
         await dash.viewTrackerCompanies()
@@ -18,7 +18,7 @@ test.describe('page data (no trackers)', () => {
         await dash.waitForCompanyName('Google LLC')
         await dash.screenshot('tracker-list-after.png')
     })
-    test('should accept updates when on non-trackers list screen', async ({ page }) => {
+    test('should accept updates when on non-trackers list screen', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await DashboardPage.webkit(page)
         await dash.addState([testDataStates.protectionsOn])
         await dash.viewThirdParties()
@@ -27,7 +27,7 @@ test.describe('page data (no trackers)', () => {
         await dash.waitForCompanyName('Google LLC')
         await dash.screenshot('non-tracker-list-after.png')
     })
-    test('does not alter the appearance of connection panel', async ({ page }) => {
+    test('does not alter the appearance of connection panel', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await DashboardPage.webkit(page)
         await dash.addState([testDataStates.protectionsOn])
         await dash.viewConnection()
@@ -38,7 +38,7 @@ test.describe('page data (no trackers)', () => {
 })
 
 test.describe('page data (with trackers)', () => {
-    test('should display correct primary screen', async ({ page }) => {
+    test('should display correct primary screen', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await DashboardPage.webkit(page)
         await dash.addState([testDataStates.cnn])
         await dash.showsPrimaryScreen()
@@ -129,7 +129,7 @@ test.describe('cookie prompt management', () => {
 })
 
 test.describe('opening breakage form', () => {
-    test('shows breakage form only', async ({ page }) => {
+    test('shows breakage form only', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'ios' })
         await dash.addState([testDataStates.google])
@@ -138,7 +138,7 @@ test.describe('opening breakage form', () => {
         await dash.screenshot('screen-breakage-form.png')
         await dash.showsOnlyDoneButton()
     })
-    test('shows breakage form without toggle (promptBreakageForm)', async ({ page }) => {
+    test('shows breakage form without toggle (promptBreakageForm)', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'promptBreakageForm', platform: 'ios' })
         await dash.addState([testDataStates.google])
@@ -146,7 +146,7 @@ test.describe('opening breakage form', () => {
         await dash.toggleIsAbsent()
         await dash.screenshot('breakage-form-prompt.png')
     })
-    test('sends toggle report', async ({ page }) => {
+    test('sends toggle report', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'toggleReport', platform: 'ios', opener: 'menu' })
         await dash.addState([testDataStates.google])
@@ -162,7 +162,7 @@ test.describe('opening breakage form', () => {
         await dash.toggleReportIsVisible()
         await dash.rejectToggleReport()
     })
-    test('shows information once', async ({ page }) => {
+    test('shows information once', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'toggleReport', platform: 'ios', opener: 'dashboard' })
         await dash.addState([testDataStates.google])
@@ -185,7 +185,7 @@ test.describe('stack based router', () => {
 test.describe('temporary reporting flows', () => {
     test.describe('opens to category selection from menu', () => {
         // sends report after selecting a category
-        test('sends report after selecting a category', async ({ page }) => {
+        test('sends report after selecting a category', { tag: '@screenshots' }, async ({ page }) => {
             const dash = await DashboardPage.webkit(page, { screen: 'categorySelection', platform: 'ios' })
             await dash.reducedMotion()
             await dash.addState([testDataStates.google])
@@ -211,7 +211,7 @@ test.describe('temporary reporting flows', () => {
     })
 
     test.describe('opens to category type selection from menu', () => {
-        test('shows category type list', async ({ page }) => {
+        test('shows category type list', { tag: '@screenshots' }, async ({ page }) => {
             const dash = await DashboardPage.webkit(page, { screen: 'categoryTypeSelection', platform: 'ios' })
             await dash.reducedMotion()
             await dash.addState([testDataStates.google])
@@ -248,83 +248,24 @@ test.describe('temporary reporting flows', () => {
     })
 })
 
-if (!process.env.CI) {
-    test.describe('screenshots', () => {
-        const states = [
-            { name: '01', state: testDataStates.protectionsOn },
-            { name: '02', state: testDataStates.protectionsOn_blocked },
-            { name: '03', state: testDataStates.protectionsOn_blocked_allowedTrackers },
-            { name: '04', state: testDataStates.protectionsOn_blocked_allowedNonTrackers },
-            { name: '05', state: testDataStates.protectionsOn_blocked_allowedTrackers_allowedNonTrackers },
-            { name: 'ad-attribution', state: testDataStates['ad-attribution'] },
-            { name: 'new-entities', state: testDataStates['new-entities'] },
-            { name: 'upgraded+secure', state: testDataStates['upgraded+secure'] },
-            { name: 'google-off', state: testDataStates['google-off'] },
-            { name: 'cnn', state: testDataStates.cnn },
-            { name: 'allowlisted', state: testDataStates.allowlisted },
-        ]
-        for (const { name, state } of states) {
-            test(name, async ({ page }) => {
-                const dash = await DashboardPage.webkit(page)
-                await dash.screenshotEachScreenForState(name, state)
-            })
-        }
-    })
-    test.describe.skip('primary screen screenshots', () => {
-        /** @type {{name: string, state: any}[]} */
-        const states = [
-            {
-                name: 'primary-insecure',
-                state: testDataStates.insecure,
-            },
-            {
-                name: 'primary-broken',
-                state: testDataStates.protectionsOff,
-            },
-            {
-                name: 'primary-user-allow-listed',
-                state: testDataStates.allowlisted,
-            },
-            {
-                name: 'primary-major-tracking-network',
-                state: testDataStates.google,
-            },
-            {
-                name: 'primary-major-tracking-network-blocked',
-                state: testDataStates['google-with-blocked'],
-            },
-            {
-                name: 'primary-none-blocked-some-trackers-allowed',
-                state: testDataStates.protectionsOn_allowedTrackers,
-            },
-            {
-                name: 'primary-none-blocked-third-party-allowed',
-                state: testDataStates.protectionsOn_allowedNonTrackers,
-            },
-            {
-                name: 'primary-none-blocked',
-                state: testDataStates.protectionsOn,
-            },
-            {
-                name: 'primary-blocked',
-                state: testDataStates.cnn,
-            },
-        ]
-        for (const { name, state } of states) {
-            test(name, async ({ page }, testInfo) => {
-                const dash = await DashboardPage.webkit(page)
-                const screen = await dash.screenshotPrimary(name, state)
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                const { certificate, ...rest } = state
-                await testInfo.attach(name, {
-                    body: JSON.stringify(rest, null, 2),
-                    contentType: 'application/json',
-                })
-                await testInfo.attach(state + '-screen', {
-                    body: screen,
-                    contentType: 'image/png',
-                })
-            })
-        }
-    })
-}
+test.describe('screenshots', { tag: '@screenshots' }, () => {
+    const states = [
+        { name: '01', state: testDataStates.protectionsOn },
+        { name: '02', state: testDataStates.protectionsOn_blocked },
+        { name: '03', state: testDataStates.protectionsOn_blocked_allowedTrackers },
+        { name: '04', state: testDataStates.protectionsOn_blocked_allowedNonTrackers },
+        { name: '05', state: testDataStates.protectionsOn_blocked_allowedTrackers_allowedNonTrackers },
+        { name: 'ad-attribution', state: testDataStates['ad-attribution'] },
+        { name: 'new-entities', state: testDataStates['new-entities'] },
+        { name: 'upgraded+secure', state: testDataStates['upgraded+secure'] },
+        { name: 'google-off', state: testDataStates['google-off'] },
+        { name: 'cnn', state: testDataStates.cnn },
+        { name: 'allowlisted', state: testDataStates.allowlisted },
+    ]
+    for (const { name, state } of states) {
+        test(name, async ({ page }) => {
+            const dash = await DashboardPage.webkit(page)
+            await dash.screenshotEachScreenForState(name, state)
+        })
+    }
+})

--- a/integration-tests/macos.spec-int.js
+++ b/integration-tests/macos.spec-int.js
@@ -23,7 +23,7 @@ test.describe('permissions', () => {
     settingPermissions((page) => DashboardPage.webkit(page, { platform: 'macos' }))
 })
 
-test('invalid/missing certificate', async ({ page }) => {
+test('invalid/missing certificate', { tag: '@screenshots' }, async ({ page }) => {
     /** @type {DashboardPage} */
     const dash = await DashboardPage.webkit(page, { platform: 'macos' })
     await dash.addState([testDataStates['https-without-certificate']])
@@ -44,7 +44,7 @@ test('insecure certificate', async ({ page }) => {
 })
 
 test.describe('opening breakage form', () => {
-    test('shows breakage form only', async ({ page }) => {
+    test('shows breakage form only', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'macos' })
         await dash.addState([testDataStates.google])
@@ -54,7 +54,7 @@ test.describe('opening breakage form', () => {
         await dash.screenshot('screen-breakage-form.png')
         await dash.mocks.calledForClose({ screen: 'breakageForm' })
     })
-    test('shows toggle report when opened from menu', async ({ page }) => {
+    test('shows toggle report when opened from menu', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'toggleReport', platform: 'macos', opener: 'menu' })
         await dash.addState([testDataStates.google])
@@ -64,7 +64,7 @@ test.describe('opening breakage form', () => {
         await dash.screenshot('screen-toggle-report-menu.png')
         await dash.mocks.calledForClose({ screen: 'toggleReport' })
     })
-    test('shows toggle report when opened from dashboard', async ({ page }) => {
+    test('shows toggle report when opened from dashboard', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'toggleReport', platform: 'macos', opener: 'dashboard' })
         await dash.addState([testDataStates.google])
@@ -72,7 +72,7 @@ test.describe('opening breakage form', () => {
         await dash.screenshot('screen-toggle-report-dashboard.png')
         await dash.closeButtonIsHidden('toggleReport')
     })
-    test('sends toggle report', async ({ page }) => {
+    test('sends toggle report', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'toggleReport', platform: 'macos', opener: 'dashboard' })
         await dash.addState([testDataStates.google])
@@ -91,7 +91,7 @@ test.describe('opening breakage form', () => {
         await dash.toggleReportIsVisible()
         await dash.rejectToggleReport()
     })
-    test('shows information', async ({ page }) => {
+    test('shows information', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'toggleReport', platform: 'macos', opener: 'dashboard' })
         await dash.addState([testDataStates.google])
@@ -145,7 +145,7 @@ test.describe('cookie prompt management', () => {
     })
 })
 
-if (!process.env.CI) {
+test.describe('macos screenshots', { tag: '@screenshots' }, () => {
     const states = [
         { name: 'ad-attribution', state: testDataStates['ad-attribution'] },
         { name: 'new-entities', state: testDataStates['new-entities'] },
@@ -153,7 +153,7 @@ if (!process.env.CI) {
         { name: 'google-off', state: testDataStates['google-off'] },
         { name: 'cnn', state: testDataStates.cnn },
     ]
-    test.describe('screenshots', () => {
+    test.describe('states', () => {
         for (const { name, state } of states) {
             test(name, async ({ page }) => {
                 const dash = await DashboardPage.webkit(page, { platform: 'macos' })
@@ -203,4 +203,4 @@ if (!process.env.CI) {
             })
         })
     })
-}
+})

--- a/integration-tests/utils/common-flows.js
+++ b/integration-tests/utils/common-flows.js
@@ -63,7 +63,7 @@ export function toggleFlowsDenyList(dashboardFactory) {
  * @param {(page: import("@playwright/test").Page) => Promise<import("../DashboardPage").DashboardPage>} dashboardFactory
  */
 export function desktopBreakageForm(dashboardFactory) {
-    test('should show HTML breakage form and submit fields', async ({ page }) => {
+    test('should show HTML breakage form and submit fields', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await dashboardFactory(page)
         await dash.reducedMotion()
         await dash.addState([testDataStates.protectionsOn])
@@ -87,7 +87,7 @@ export function desktopBreakageForm(dashboardFactory) {
         await dash.toggleProtectionsOff(eventOrigin)
         await dash.mocks.calledForToggleAllowList('protections-off', eventOrigin)
     })
-    test('toggling protections back on, from breakage form', async ({ page }) => {
+    test('toggling protections back on, from breakage form', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await dashboardFactory(page)
         await dash.reducedMotion()
         await dash.addState([testDataStates.allowlisted])
@@ -97,7 +97,7 @@ export function desktopBreakageForm(dashboardFactory) {
         await dash.screenshot('breakage-form-allowlisted.png')
         await dash.toggleProtectionsOn(eventOrigin)
     })
-    test('broken (remote disabled) breakage form', async ({ page }) => {
+    test('broken (remote disabled) breakage form', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await dashboardFactory(page)
         await dash.reducedMotion()
         await dash.addState([testDataStates.protectionsOff])
@@ -109,25 +109,8 @@ export function desktopBreakageForm(dashboardFactory) {
 /**
  * @param {(page: import("@playwright/test").Page) => Promise<import("../DashboardPage").DashboardPage>} dashboardFactory
  */
-export function mobileBreakageForm(dashboardFactory) {
-    test('should ', async ({ page }) => {
-        const dash = await dashboardFactory(page)
-        await dash.reducedMotion()
-        await dash.addState([testDataStates.protectionsOn])
-        await dash.showsAlternativeLayout()
-        await dash.clicksWebsiteNotWorking()
-
-        await dash.screenshot('breakage-form.png')
-        await dash.submitBreakageForm()
-        await dash.screenshot('breakage-form-message.png')
-    })
-}
-
-/**
- * @param {(page: import("@playwright/test").Page) => Promise<import("../DashboardPage").DashboardPage>} dashboardFactory
- */
 export function settingPermissions(dashboardFactory) {
-    test('permissions toggles', async ({ page }) => {
+    test('permissions toggles', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await dashboardFactory(page)
         await dash.addState([testDataStates.permissions])
         await dash.screenshot('permissions.png')

--- a/integration-tests/windows.spec-int.js
+++ b/integration-tests/windows.spec-int.js
@@ -16,7 +16,7 @@ test.describe('breakage form', () => {
 })
 
 test.describe('opening breakage form', () => {
-    test('shows breakage form only', async ({ page }) => {
+    test('shows breakage form only', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.windows(page, { screen: 'breakageForm' })
         await dash.addState([testDataStates.google])
@@ -34,14 +34,14 @@ test.describe('permissions', () => {
     settingPermissions((page) => DashboardPage.windows(page))
 })
 
-test('windows is excluded from invalid/missing certificate', async ({ page }) => {
+test('windows is excluded from invalid/missing certificate', { tag: '@screenshots' }, async ({ page }) => {
     /** @type {DashboardPage} */
     const dash = await DashboardPage.windows(page)
     await dash.addState([testDataStates['https-without-certificate']])
     await dash.screenshot('invalid-cert.png')
 })
 
-test('upgraded requests without certs always show as secure', async ({ page }) => {
+test('upgraded requests without certs always show as secure', { tag: '@screenshots' }, async ({ page }) => {
     /** @type {DashboardPage} */
     const dash = await DashboardPage.windows(page)
     await dash.addState([testDataStates['upgraded+secure+without-certs']])
@@ -96,7 +96,7 @@ test.describe('cookie prompt management', () => {
     })
 })
 
-if (!process.env.CI) {
+test.describe('windows screenshots', { tag: '@screenshots' }, () => {
     const states = [
         { name: 'ad-attribution', state: testDataStates['ad-attribution'] },
         { name: 'new-entities', state: testDataStates['new-entities'] },
@@ -104,7 +104,7 @@ if (!process.env.CI) {
         { name: 'google-off', state: testDataStates['google-off'] },
         { name: 'cnn', state: testDataStates.cnn },
     ]
-    test.describe('screenshots', () => {
+    test.describe('states', () => {
         for (const { name, state } of states) {
             test(name, async ({ page }) => {
                 const dash = await DashboardPage.windows(page)
@@ -112,4 +112,4 @@ if (!process.env.CI) {
             })
         }
     })
-}
+})

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "test.int": "playwright test",
         "test.int.ui": "playwright test --ui",
         "test.int.headed": "playwright test --headed",
-        "test.int.update-screenshots": "npm run test.int -- --update-snapshots",
+        "test.int.update-screenshots": "npm run test.int -- --grep @screenshots --update-snapshots",
         "test.int-debug": "playwright test --headed --debug",
         "test.clean-tree": "npm run build && sh scripts/check-for-changes.sh",
         "verify.artifacts": "node scripts/verify-artifacts.mjs",

--- a/shared/js/ui/hooks/useRipple.js
+++ b/shared/js/ui/hooks/useRipple.js
@@ -66,7 +66,6 @@ export function addRippleTo(elements) {
         while (instances.length) {
             const last = instances.pop()
             last.destroy()
-            console.log('destroy')
         }
     }
 }

--- a/v2/data-provider.js
+++ b/v2/data-provider.js
@@ -329,7 +329,9 @@ export function useFetcher() {
     /** @type {(msg: import("../shared/js/browser/common.js").Msg) => Promise<any>} */
     return useCallback(async (msg) => {
         try {
-            console.log('📤 [outgoing useFetcher]', msg)
+            if (!window.__ddg_integration_test) {
+                console.log('📤 [outgoing useFetcher]', msg)
+            }
             return comms.fetch(msg)
         } catch (error) {
             console.error('Error:', error)

--- a/v2/navigation.jsx
+++ b/v2/navigation.jsx
@@ -81,7 +81,9 @@ export function useCanPop() {
  * @param {NavEvent} event
  */
 function navReducer(state, event) {
-    console.log('📩', event, state)
+    if (!window.__ddg_integration_test) {
+        console.log('📩', event, state)
+    }
     switch (state.state) {
         case 'transitioning': {
             switch (event.type) {


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @mgurgel 

https://app.asana.com/0/0/1207868371624522/f

## Description:

Use the recommended approach for splitting up tests.

Now, we can use the `{ tag: '@screenshots' }` on any `test` or `describe` block.


**run all screenshot tests only** 
```
npm run test.int -- --grep @screenshots
```

**run all none-screenshot tests only** 

```
npm run test.int -- --grep-invert @screenshots
```
