### PR TITLE
put webBreakageForm behind flag, enabled by default

### DIFF
--- a/integration-tests/Mocks.js
+++ b/integration-tests/Mocks.js
@@ -192,6 +192,11 @@ export class Mocks {
             ])
             return
         }
+        if (this.platform.name === 'android') {
+            const out = await this.outgoing({ names: ['submitBrokenSiteReport'] })
+            expect(out).toMatchObject([['submitBrokenSiteReport', JSON.stringify({ category: '', description: '' })]])
+            return
+        }
         throw new Error('unreachable. mockCalledForSubmitBreakageForm must be handled')
     }
 

--- a/integration-tests/android.spec-int.js
+++ b/integration-tests/android.spec-int.js
@@ -53,6 +53,22 @@ test.describe('Protections toggle', () => {
     toggleFlows((page) => DashboardPage.android(page))
 })
 
+test.describe('Breakage form', () => {
+    test('displays web breakage form', async ({ page }) => {
+        const dash = await DashboardPage.android(page)
+        await dash.addState([testDataStates['webBreakageForm-enabled']])
+        await dash.clicksWebsiteNotWorking()
+        await dash.submitBreakageForm()
+        await dash.mocks.calledForSubmitBreakageForm({ category: 'videos', description: 'TEST' })
+    })
+    test('uses native breakage form', async ({ page }) => {
+        const dash = await DashboardPage.android(page)
+        await dash.addState([testDataStates['webBreakageForm-disabled']])
+        await dash.clicksWebsiteNotWorking()
+        await dash.mocks.calledForShowBreakageForm()
+    })
+})
+
 test.describe('Close', () => {
     test('pressing close should call native API', async ({ page }) => {
         const dash = await DashboardPage.android(page)

--- a/schema/__generated__/schema.parsers.mjs
+++ b/schema/__generated__/schema.parsers.mjs
@@ -156,6 +156,10 @@ export const primaryScreenSchema = z.object({
     layout: z.union([z.literal("default"), z.literal("highlighted-protections-toggle")])
 });
 
+export const webBreakageFormSchema = z.object({
+    state: z.union([z.literal("enabled"), z.literal("disabled")])
+});
+
 export const eventOriginSchema = z.object({
     screen: screenKindSchema
 });
@@ -215,7 +219,8 @@ export const fireButtonDataSchema = z.object({
 });
 
 export const remoteFeatureSettingsSchema = z.object({
-    primaryScreen: primaryScreenSchema.optional()
+    primaryScreen: primaryScreenSchema.optional(),
+    webBreakageForm: webBreakageFormSchema.optional()
 });
 
 export const setProtectionParamsSchema = z.object({

--- a/schema/__generated__/schema.types.ts
+++ b/schema/__generated__/schema.types.ts
@@ -492,12 +492,16 @@ export interface FireOption {
  */
 export interface RemoteFeatureSettings {
   primaryScreen?: PrimaryScreen;
+  webBreakageForm?: WebBreakageForm;
 }
 export interface PrimaryScreen {
   /**
    * A string to represent different screen layouts
    */
   layout: "default" | "highlighted-protections-toggle";
+}
+export interface WebBreakageForm {
+  state: "enabled" | "disabled";
 }
 export interface SetProtectionParams {
   isProtected: boolean;

--- a/schema/remote-feature-settings.json
+++ b/schema/remote-feature-settings.json
@@ -17,6 +17,19 @@
                     "examples": ["default", "highlighted-protections-toggle"]
                 }
             }
+        },
+        "webBreakageForm": {
+            "title": "WebBreakageForm",
+            "type": "object",
+            "required": ["state"],
+            "additionalProperties": false,
+            "properties": {
+                "state": {
+                    "type": "string",
+                    "enum": ["enabled", "disabled"],
+                    "default": "enabled"
+                }
+            }
         }
     }
 }

--- a/shared/js/browser/common.js
+++ b/shared/js/browser/common.js
@@ -4,7 +4,8 @@
  * @typedef {{
  *   tab: import('./utils/request-details.mjs').TabData,
  *   emailProtectionUserData?: import('../../../schema/__generated__/schema.types').EmailProtectionUserData,
- *   fireButton?: { enabled: boolean }
+ *   fireButton?: { enabled: boolean },
+ *   featureSettings?: import('../../../schema/__generated__/schema.types').RemoteFeatureSettings | undefined
  * }} BackgroundTabData
  */
 /**

--- a/shared/js/browser/utils/communication-mocks.mjs
+++ b/shared/js/browser/utils/communication-mocks.mjs
@@ -219,6 +219,9 @@ export function mockAndroidApis() {
             toggleAllowlist(arg) {
                 window.__playwright.mocks.outgoing.push(['toggleAllowlist', arg])
             },
+            submitBrokenSiteReport(arg) {
+                window.__playwright.mocks.outgoing.push(['submitBrokenSiteReport', arg])
+            },
         }
     } catch (e) {
         console.error("❌couldn't set up mocks")

--- a/shared/js/ui/platform-features.mjs
+++ b/shared/js/ui/platform-features.mjs
@@ -141,15 +141,30 @@ export class FeatureSettings {
     /**
      * @param {object} params
      * @param {import("../../../schema/__generated__/schema.types").PrimaryScreen} [params.primaryScreen]
+     * @param {import("../../../schema/__generated__/schema.types").WebBreakageForm} [params.webBreakageForm]
      */
     constructor(params) {
         /** @type {import("../../../schema/__generated__/schema.types").PrimaryScreen} */
         this.primaryScreen = params.primaryScreen || { layout: 'default' }
+        /** @type {import("../../../schema/__generated__/schema.types").WebBreakageForm} */
+        this.webBreakageForm = params.webBreakageForm || { state: 'enabled' }
     }
+
     /**
-     *
+     * @param {import("../../../schema/__generated__/schema.types").RemoteFeatureSettings|undefined} settings
+     * @param {Platform} platform
      */
-    static default() {
-        return new FeatureSettings({})
+    static create(settings, platform) {
+        switch (platform.name) {
+            case 'android': {
+                return new FeatureSettings({
+                    webBreakageForm: { state: 'disabled' },
+                    ...settings,
+                })
+            }
+            default: {
+                return new FeatureSettings(settings || {})
+            }
+        }
     }
 }

--- a/shared/js/ui/views/tests/generate-data.mjs
+++ b/shared/js/ui/views/tests/generate-data.mjs
@@ -770,6 +770,20 @@ export const createDataStates = (google, cnn) => {
                 screen: 'promptBreakageForm',
             },
         }),
+        'webBreakageForm-enabled': new MockData({
+            url: 'https://example.com',
+            requests: [],
+            remoteFeatureSettings: {
+                webBreakageForm: { state: 'enabled' },
+            },
+        }),
+        'webBreakageForm-disabled': new MockData({
+            url: 'https://example.com',
+            requests: [],
+            remoteFeatureSettings: {
+                webBreakageForm: { state: 'disabled' },
+            },
+        }),
     }
 }
 

--- a/types.ts
+++ b/types.ts
@@ -28,6 +28,7 @@ interface Window {
         showBreakageForm: (...args: any[]) => any
         openInNewTab: (payload: string) => void
         openSettings: (payload: string) => void
+        submitBrokenSiteReport: (payload: string) => void
     }
     /**
      * This is set in Playwright tests

--- a/v2/components/protection-header.jsx
+++ b/v2/components/protection-header.jsx
@@ -1,11 +1,10 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { h } from 'preact'
 import { ProtectionHeader as ProtectionHeaderComponent } from '../../shared/js/ui/templates/protection-header'
-import { useData, useFeatures, useFetcher, useToggle } from '../data-provider'
+import { useData, useFeatures, useFeatureSettings, useFetcher, useToggle } from '../data-provider'
 import { TextLink } from '../../shared/js/ui/components/text-link'
 import { useNav } from '../navigation'
 import { ns } from '../../shared/js/ui/base/localize'
-import { isAndroid } from '../../shared/js/ui/environment-check'
 import { CheckBrokenSiteReportHandledMessage } from '../../shared/js/browser/common'
 
 export function ProtectionHeader() {
@@ -14,6 +13,7 @@ export function ProtectionHeader() {
     const onToggle = useToggle()
     const fetcher = useFetcher()
     const { breakageScreen } = useFeatures()
+    const featureSettings = useFeatureSettings()
 
     return (
         <div data-testid="protectionHeader">
@@ -24,7 +24,7 @@ export function ProtectionHeader() {
                             // this is a workaround for ios, to ensure we follow the old implementation
                             fetcher(new CheckBrokenSiteReportHandledMessage())
                                 .then(() => {
-                                    if (!isAndroid()) {
+                                    if (featureSettings.webBreakageForm.state === 'enabled') {
                                         push(breakageScreen)
                                     }
                                 })

--- a/v2/data-provider.js
+++ b/v2/data-provider.js
@@ -78,7 +78,7 @@ class DataChannel extends EventTarget {
     /**
      * @param {import('../shared/js/browser/common.js').BackgroundTabData} data
      */
-    accept({ tab, emailProtectionUserData, fireButton }) {
+    accept({ tab, emailProtectionUserData, fireButton, featureSettings }) {
         if (tab) {
             if (tab.locale) {
                 // @ts-ignore
@@ -102,7 +102,7 @@ class DataChannel extends EventTarget {
             this.emailProtectionUserData = emailProtectionUserData
         }
         this.fireButton = fireButton
-        this.featureSettings = new FeatureSettings({})
+        this.featureSettings = FeatureSettings.create(featureSettings, platform)
 
         this.setSiteProperties()
         this.setHttpsMessage()
@@ -312,6 +312,14 @@ export function useData() {
  */
 export function useFeatures() {
     return dc.lastValue().features
+}
+
+/**
+ * Static access to `featureSettings` since it doesn't change
+ * @return {DataChannelPublicData['featureSettings']}
+ */
+export function useFeatureSettings() {
+    return dc.lastValue().featureSettings
 }
 
 /**


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:**
-->

## Description:

<!-- Explain what is being changed, why, etc -->

## Steps to test this PR:

- `npm run preview`
- 1: ensure the default is still 'disabled' on Android
  - visit a regular state, like http://localhost:3000/html/android.html?state=cnn
  - verify that clicking on 'Website not working?' does nothing 
- 2: now use `?state=webBreakageForm-enabled` and try again
  - now, the web breakage form should show

**Update:** 

- [x] Tested and approved via https://app.asana.com/0/72649045549333/1207977556129390/f
