### PR TITLE
fixed back + forward swiping

### DIFF
--- a/build/app/public/js/base.js
+++ b/build/app/public/js/base.js
@@ -17541,7 +17541,7 @@
     }, [state.state]);
     p2(() => {
       function popstateHandler() {
-        const currentUrlParams = new URLSearchParams(location.href);
+        const currentUrlParams = new URLSearchParams(location.search);
         const currentURLStack = currentUrlParams.getAll("stack");
         const navigationIntentionIsForwards = currentURLStack.length > state.stack.length;
         if (navigationIntentionIsForwards) {
@@ -17557,7 +17557,7 @@
       return () => {
         window.removeEventListener("popstate", popstateHandler);
       };
-    }, [state.state, state.via, props.animate]);
+    }, [state.state, state.stack, state.via, props.animate]);
     const canPop = T2(() => {
       if (state.state === "transitioning") {
         return state.commit.length > 1 || state.stack.length > 1;

--- a/build/app/public/js/base.js
+++ b/build/app/public/js/base.js
@@ -17542,10 +17542,11 @@
         return;
       }
       function popstateHandler() {
-        const curr = new URLSearchParams(location.href);
-        const currStack = curr.getAll("stack");
-        if (currStack.length > state.stack.length) {
-          const lastEntry = currStack[currStack.length - 1];
+        const currentUrlParams = new URLSearchParams(location.href);
+        const currentURLStack = currentUrlParams.getAll("stack");
+        const navigationIntentionIsForwards = currentURLStack.length > state.stack.length;
+        if (navigationIntentionIsForwards) {
+          const lastEntry = currentURLStack[currentURLStack.length - 1];
           if (isScreenName(lastEntry)) {
             dispatch({ type: "push", name: lastEntry, opts: { animate: props.animate && isAndroid() } });
           }

--- a/build/app/public/js/base.js
+++ b/build/app/public/js/base.js
@@ -17540,9 +17540,6 @@
       };
     }, [state.state]);
     p2(() => {
-      if (state.state !== "settled") {
-        return;
-      }
       function popstateHandler() {
         const currentUrlParams = new URLSearchParams(location.href);
         const currentURLStack = currentUrlParams.getAll("stack");

--- a/build/app/public/js/base.js
+++ b/build/app/public/js/base.js
@@ -17478,7 +17478,9 @@
           }
           case "pop": {
             if (state.stack.length < 2) {
-              console.warn("ignoring a `pop` event", window.location.search);
+              if (!window.__ddg_integration_test) {
+                console.warn("ignoring a `pop` event", window.location.search);
+              }
               return state;
             }
             if (!event.opts.animate) {

--- a/integration-tests/AltBreakageFlows.js
+++ b/integration-tests/AltBreakageFlows.js
@@ -40,6 +40,11 @@ export class AltBreakageFlows {
     async showsReportFromPrimaryScreen() {
         const { page } = this.dash
         await page.getByRole('link', { name: 'Website not working?' }).click()
+        await this.breakageFormIsVisible()
+    }
+
+    async breakageFormIsVisible() {
+        const { page } = this.dash
         await page.getByText("What's not working on this").waitFor({ timeout: 1000 })
     }
 

--- a/integration-tests/DashboardPage.js
+++ b/integration-tests/DashboardPage.js
@@ -49,7 +49,7 @@ export class DashboardPage {
 
     async showsPrimaryScreen() {
         await this.page.waitForFunction(() => typeof window.__playwright !== 'undefined')
-        await this.connectInfoLink().waitFor()
+        await this.connectInfoLink().waitFor({ timeout: 5000 })
     }
 
     async showsAlternativeLayout() {
@@ -75,7 +75,6 @@ export class DashboardPage {
      * @param {{ skipInCI?: boolean }} [opts]
      */
     async screenshotEachScreenForState(name, state, opts = {}) {
-        await this.reducedMotion()
         await this.addState([state])
         await this.showsPrimaryScreen()
         await this.screenshot(name + '-state-primary.png', opts)
@@ -577,6 +576,9 @@ export class DashboardPage {
 
     async clicksWebsiteNotWorking() {
         await this.page.getByRole('link', { name: 'Website not working?' }).click({ timeout: 1000 })
+    }
+    async showsBreakageForm() {
+        await this.page.getByText('Submitting an anonymous').waitFor({ timeout: 5000 })
     }
 
     async showRemoteDisabled() {

--- a/integration-tests/android.spec-int.js
+++ b/integration-tests/android.spec-int.js
@@ -129,6 +129,7 @@ test.describe('Android screenshots', { tag: '@screenshots' }, () => {
         ]
         for (const { name, state } of states) {
             test(name, async ({ page }) => {
+                await page.emulateMedia({ reducedMotion: 'reduce' })
                 const dash = await DashboardPage.android(page)
                 await dash.screenshotEachScreenForState(name, state)
             })

--- a/integration-tests/ios.spec-int.js
+++ b/integration-tests/ios.spec-int.js
@@ -174,14 +174,33 @@ test.describe('opening breakage form', () => {
 })
 
 test.describe('stack based router', () => {
-    test('goes back and forward', async ({ page }) => {
+    test('goes back and forward in categorySelection flow', async ({ page }) => {
         const dash = await DashboardPage.webkit(page, { breakageScreen: 'categorySelection', platform: 'ios' })
         await dash.reducedMotion()
         await dash.addState([testDataStates.google])
         await dash.breakage.showsReportFromPrimaryScreen()
         await dash.nav.goesBackToPrimaryScreen()
     })
+    test('goes back and forward generally', async ({ page }) => {
+        const dash = await DashboardPage.webkit(page, { platform: 'ios' })
+        await dash.reducedMotion()
+        await dash.addState([testDataStates.google])
+        await dash.clicksWebsiteNotWorking()
+        await dash.showsBreakageForm()
+
+        // needed to allow the router to settle
+        // playwright is too fast here and is doing something a user never could
+        await page.waitForTimeout(100)
+        await page.goBack()
+        await dash.showsPrimaryScreen()
+
+        // same as previous wait point
+        await page.waitForTimeout(100)
+        await page.goForward()
+        await dash.showsBreakageForm()
+    })
 })
+
 test.describe('temporary reporting flows', () => {
     test.describe('opens to category selection from menu', () => {
         // sends report after selecting a category
@@ -276,6 +295,7 @@ test.describe('screenshots', { tag: '@screenshots' }, () => {
     ]
     for (const { name, state } of states) {
         test(name, async ({ page }) => {
+            await page.emulateMedia({ reducedMotion: 'reduce' })
             const dash = await DashboardPage.webkit(page)
             await dash.screenshotEachScreenForState(name, state)
         })

--- a/integration-tests/macos.spec-int.js
+++ b/integration-tests/macos.spec-int.js
@@ -164,6 +164,7 @@ test.describe('macos screenshots', { tag: '@screenshots' }, () => {
     test.describe('states', () => {
         for (const { name, state } of states) {
             test(name, async ({ page }) => {
+                await page.emulateMedia({ reducedMotion: 'reduce' })
                 const dash = await DashboardPage.webkit(page, { platform: 'macos' })
                 await dash.screenshotEachScreenForState(name, state)
             })

--- a/integration-tests/windows.spec-int.js
+++ b/integration-tests/windows.spec-int.js
@@ -107,6 +107,7 @@ test.describe('windows screenshots', { tag: '@screenshots' }, () => {
     test.describe('states', () => {
         for (const { name, state } of states) {
             test(name, async ({ page }) => {
+                await page.emulateMedia({ reducedMotion: 'reduce' })
                 const dash = await DashboardPage.windows(page)
                 await dash.screenshotEachScreenForState(name, state)
             })

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "tsc.watch": "tsc --watch",
         "test": "npm run verify.local",
         "test.unit": "node schema/schema.test.mjs && node shared/js/browser/utils/request-details.test.mjs && node shared/locales/validate-locales.test.mjs && node scripts/verify-artifacts.test.mjs",
-        "test.int": "playwright test",
+        "test.int": "npm run build.debug && playwright test",
         "test.int.ui": "playwright test --ui",
         "test.int.headed": "playwright test --headed",
         "test.int.update-screenshots": "npm run test.int -- --grep @screenshots --update-snapshots",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "start": "npm run dev",
         "dev": "chokidar \"v2\" \"shared\" 'debugger' \"schema/*.json\" -c \"npm run build.debug\" --initial \"npm run build.debug\"",
-        "build.watch.prod": "chokidar \"shared\" \"schema/*.json\" -c \"npm run build\" --initial \"npm run build\"",
+        "build.watch.prod": "chokidar \"v2\" \"shared\" \"schema/*.json\" -c \"npm run build\" --initial \"npm run build\"",
         "build": "node scripts/build.js",
         "build.debug": "node scripts/build.js --debug",
         "docs": "typedoc",

--- a/v2/navigation.jsx
+++ b/v2/navigation.jsx
@@ -141,7 +141,9 @@ function navReducer(state, event) {
                 }
                 case 'pop': {
                     if (state.stack.length < 2) {
-                        console.warn('ignoring a `pop` event', window.location.search)
+                        if (!window.__ddg_integration_test) {
+                            console.warn('ignoring a `pop` event', window.location.search)
+                        }
                         return state
                     }
                     if (!event.opts.animate) {

--- a/v2/navigation.jsx
+++ b/v2/navigation.jsx
@@ -231,7 +231,7 @@ export function Navigation(props) {
          * - otherwise, it's just a 'back' action, so we can `pop` an item from the stack as usual
          */
         function popstateHandler() {
-            const currentUrlParams = new URLSearchParams(location.href)
+            const currentUrlParams = new URLSearchParams(location.search)
             const currentURLStack = currentUrlParams.getAll('stack')
             const navigationIntentionIsForwards = currentURLStack.length > state.stack.length
 
@@ -250,7 +250,7 @@ export function Navigation(props) {
         return () => {
             window.removeEventListener('popstate', popstateHandler)
         }
-    }, [state.state, state.via, props.animate])
+    }, [state.state, state.stack, state.via, props.animate])
 
     const canPop = useCallback(() => {
         // const curr = state.stack[state.stack.length - 1];

--- a/v2/navigation.jsx
+++ b/v2/navigation.jsx
@@ -223,11 +223,6 @@ export function Navigation(props) {
 
     // reflect to the URL
     useEffect(() => {
-        // only act on popstate events when settled
-        if (state.state !== 'settled') {
-            return
-        }
-
         /**
          * 'popstateHandler' is invoked on back AND forward navigations
          * - To detect if it's a 'forward' intention, we look at the current 'stack' in the url params

--- a/v2/navigation.jsx
+++ b/v2/navigation.jsx
@@ -226,11 +226,20 @@ export function Navigation(props) {
             return
         }
 
+        /**
+         * 'popstateHandler' is invoked on back AND forward navigations
+         * - To detect if it's a 'forward' intention, we look at the current 'stack' in the url params
+         *   and compare it to our local state. So if the url stack has 1 more item than our state, we know
+         *   it's a 'forward' action.
+         * - otherwise, it's just a 'back' action, so we can `pop` an item from the stack as usual
+         */
         function popstateHandler() {
-            const curr = new URLSearchParams(location.href)
-            const currStack = curr.getAll('stack')
-            if (currStack.length > state.stack.length) {
-                const lastEntry = currStack[currStack.length - 1]
+            const currentUrlParams = new URLSearchParams(location.href)
+            const currentURLStack = currentUrlParams.getAll('stack')
+            const navigationIntentionIsForwards = currentURLStack.length > state.stack.length
+
+            if (navigationIntentionIsForwards) {
+                const lastEntry = currentURLStack[currentURLStack.length - 1]
                 if (isScreenName(lastEntry)) {
                     dispatch({ type: 'push', name: lastEntry, opts: { animate: props.animate && isAndroid() } })
                 }

--- a/v2/navigation.jsx
+++ b/v2/navigation.jsx
@@ -10,6 +10,12 @@ import { NonTrackersScreen } from './screens/non-trackers-screen'
 import { ConsentManagedScreen } from './screens/consent-managed-screen'
 import { ToggleReportScreen } from './screens/toggle-report-screen'
 import { ChoiceBreakageForm, CategorySelection, CategoryTypeSelection, ChoiceToggleScreen } from './screens/choice-problem'
+import { isAndroid } from '../shared/js/ui/environment-check'
+import { screenKindSchema } from '../schema/__generated__/schema.parsers.mjs'
+
+/**
+ * @typedef {import('../schema/__generated__/schema.types').EventOrigin['screen']} ScreenName
+ */
 
 /** @type {Record<ScreenName, { kind: 'subview' | 'root', component: () => any}>} */
 const availableScreens = {
@@ -33,9 +39,8 @@ const availableScreens = {
     cookieHidden: { kind: 'subview', component: () => <ConsentManagedScreen cosmetic={true} /> },
 }
 
-/**
- * @typedef {import('../schema/__generated__/schema.types').EventOrigin['screen']} ScreenName
- */
+// Typescript isn't smart enough to understand what Object.entries does here :(
+const entries = /** @type {[ScreenName, { kind: 'subview' | 'root', component: () => any}][]} */ (Object.entries(availableScreens))
 
 const NavContext = createContext({
     /** @type {(name: ScreenName, params?: Record<string, string>) => void} */
@@ -45,10 +50,6 @@ const NavContext = createContext({
     /** @type {() => void} */
     pop() {
         throw new Error('not implemented')
-    },
-    /** @type {(stack: ScreenName[]) => void} */
-    goto(stack) {
-        throw new Error('not implemented ' + stack)
     },
     params: new URLSearchParams(''),
     /** @type {() => boolean} */
@@ -74,6 +75,14 @@ export function useCanPop() {
     const { screen } = useContext(ScreenContext)
     const { canPopFrom } = useNav()
     return canPopFrom(screen)
+}
+
+/**
+ * @param {any} input;
+ * @returns {input is ScreenName}
+ */
+function isScreenName(input) {
+    return screenKindSchema.safeParse(input).success
 }
 
 /**
@@ -115,15 +124,9 @@ function navReducer(state, event) {
                     }
                 }
                 case 'push': {
-                    const nextParams = new URLSearchParams(state.params)
-                    for (let [key, value] of Object.entries(event.params)) {
-                        // using 'set' to override previous values.
-                        nextParams.set(key, value)
-                    }
                     if (!event.opts.animate) {
                         return {
                             ...state,
-                            params: nextParams,
                             stack: state.stack.concat(event.name),
                             state: /** @type {const} */ ('settled'),
                             via: 'push',
@@ -131,7 +134,6 @@ function navReducer(state, event) {
                     }
                     return {
                         ...state,
-                        params: nextParams,
                         stack: state.stack.concat(event.name),
                         state: /** @type {const} */ ('transitioning'),
                         via: 'push',
@@ -139,7 +141,7 @@ function navReducer(state, event) {
                 }
                 case 'pop': {
                     if (state.stack.length < 2) {
-                        console.warn('ignoring a `pop` event')
+                        console.warn('ignoring a `pop` event', window.location.search)
                         return state
                     }
                     if (!event.opts.animate) {
@@ -173,16 +175,15 @@ function navReducer(state, event) {
 
 /**
  * @typedef {{ animate: boolean }} ActionOpts
- * @typedef {{ type: 'push', name: ScreenName, opts: ActionOpts, params: Record<string, string>}
+ * @typedef {{ type: 'push', name: ScreenName, opts: ActionOpts}
  *   | {type: 'pop', opts: ActionOpts}
  *   | {type: 'goto', stack: ScreenName[], opts: ActionOpts}
  *   | {type: 'end'}
  * } NavEvent
  * @typedef {{
  *    commit: string[],
- *    stack: string[],
+ *    stack: ScreenName[],
  *    state: 'initial' | 'settled' | 'transitioning',
- *    params: URLSearchParams,
  *    via: NavEvent['type'] | string | undefined
  * }} NavState
  */
@@ -198,7 +199,6 @@ export function Navigation(props) {
         stack: props.stack,
         state: 'initial',
         commit: [],
-        params: props.params,
         via: undefined,
     })
 
@@ -221,37 +221,30 @@ export function Navigation(props) {
 
     // reflect to the URL
     useEffect(() => {
-        // only act on navigations when settled
+        // only act on popstate events when settled
         if (state.state !== 'settled') {
             return
         }
 
-        if (state.via === 'push') {
-            const url = new URL(window.location.href)
-            url.searchParams.delete('stack')
-            for (let string of state.stack) {
-                url.searchParams.append('stack', string)
+        function popstateHandler() {
+            const curr = new URLSearchParams(location.href)
+            const currStack = curr.getAll('stack')
+            if (currStack.length > state.stack.length) {
+                const lastEntry = currStack[currStack.length - 1]
+                if (isScreenName(lastEntry)) {
+                    dispatch({ type: 'push', name: lastEntry, opts: { animate: props.animate && isAndroid() } })
+                }
+            } else {
+                dispatch({ type: 'pop', opts: { animate: props.animate && isAndroid() } })
             }
-            for (let [key, value] of Object.entries(state.params)) {
-                url.searchParams.set(key, value)
-            }
-            window.history.pushState({}, '', url)
         }
 
-        if (state.via === 'pop') {
-            window.history.go(-1)
-        }
-
-        function handler() {
-            dispatch({ type: 'pop', opts: { animate: props.animate } })
-        }
-
-        window.addEventListener('popstate', handler)
+        window.addEventListener('popstate', popstateHandler)
 
         return () => {
-            window.removeEventListener('popstate', handler)
+            window.removeEventListener('popstate', popstateHandler)
         }
-    }, [state.state, state.params, state.via, props.animate])
+    }, [state.state, state.via, props.animate])
 
     const canPop = useCallback(() => {
         // const curr = state.stack[state.stack.length - 1];
@@ -276,13 +269,44 @@ export function Navigation(props) {
     }, [state.state, state.stack, state.commit])
 
     const api = {
-        push: (name, params = {}) => dispatch({ type: 'push', name, opts: { animate: props.animate }, params }),
-        pop: () => dispatch({ type: 'pop', opts: { animate: props.animate } }),
-        goto: (stack) => dispatch({ type: 'goto', stack, opts: { animate: props.animate } }),
+        /**
+         * @param {ScreenName} name
+         * @param {Record<string, any>} params
+         */
+        push: (name, params = {}) => {
+            const url = new URL(window.location.href)
+
+            for (let [key, value] of Object.entries(params)) {
+                // using 'set' to override any previous values.
+                url.searchParams.set(key, value)
+            }
+
+            // reset the navigation stack
+            url.searchParams.delete('stack')
+            for (let string of state.stack) {
+                url.searchParams.append('stack', string)
+            }
+            url.searchParams.append('stack', name)
+
+            // reflect the new as a push
+            window.history.pushState({}, '', url)
+
+            // change component state
+            dispatch({ type: 'push', name, opts: { animate: props.animate } })
+        },
+        pop: () => {
+            // remove a history entry
+            window.history.go(-1)
+
+            // change component state
+            dispatch({ type: 'pop', opts: { animate: props.animate } })
+        },
         canPop: canPop,
         canPopFrom: canPopFrom,
         screen: screen,
-        params: state.params,
+        get params() {
+            return new URLSearchParams(location.search)
+        },
     }
 
     // console.groupCollapsed('Navigation Render state')
@@ -305,32 +329,32 @@ export function Navigation(props) {
                     transform: `translateX(` + -((state.stack.length - 1) * 100) + '%)',
                 }}
             >
-                {Object.entries(availableScreens).map(([name, item]) => {
-                    const inStack = state.stack.includes(name)
-                    const commiting = state.commit.includes(name)
-                    const current = state.stack[state.stack.length - 1] === name
+                {entries.map(([screenName, item]) => {
+                    const inStack = state.stack.includes(screenName)
+                    const commiting = state.commit.includes(screenName)
+                    const current = state.stack[state.stack.length - 1] === screenName
                     if (!inStack && !commiting) return null
                     if (item.kind === 'root') {
                         return (
-                            <ScreenContext.Provider value={{ screen: /** @type {ScreenName} */ (name) }}>
-                                <section className="app-height" key={name}>
+                            <ScreenContext.Provider value={{ screen: screenName }}>
+                                <section className="app-height" key={screenName}>
                                     {item.component()}
                                 </section>
                             </ScreenContext.Provider>
                         )
                     }
-                    const translateValue = state.stack.includes(name)
-                        ? state.stack.indexOf(name)
-                        : state.commit.includes(name)
-                        ? state.commit.indexOf(name)
+                    const translateValue = state.stack.includes(screenName)
+                        ? state.stack.indexOf(screenName)
+                        : state.commit.includes(screenName)
+                        ? state.commit.indexOf(screenName)
                         : 0
                     const cssProp = `translateX(${translateValue * 100}%)`
                     return (
-                        <ScreenContext.Provider value={{ screen: /** @type {ScreenName} */ (name) }}>
+                        <ScreenContext.Provider value={{ screen: screenName }}>
                             <section
                                 data-current={String(current)}
                                 className="sliding-subview-v2"
-                                key={name}
+                                key={screenName}
                                 style={{ transform: cssProp }}
                             >
                                 {item.component()}


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

https://app.asana.com/0/1201141132935289/1208104043193957/f

<!-- Optional fields
**CC:**
**Depends on:**
-->

## Description:

**Before:**
 - we were transitioning the UI to the next state, just before we called `window.history.pushState`
 - this caused a couple of problems on iOS
    - First, the 'preview' you see when dragging from the left or right (to go back or forward) would not be the correct screen
    - Second, the actual navigation action when invoked in this manner was broken - it didn't take you back to the screen you were expecting.

**After:**
- this PR just changes the order of execution: we FIRST call `window.history.pushState(...)` which allows iOS to take a 'snapshot' of the correct screen and then we alter the UI.

<!-- Explain what is being changed, why, etc -->

## Steps to test this PR:

The videos below show it working correctly on iOS + Android, but if you want to verify locally, you can follow this:

- npm run preview
- open the following page http://127.0.0.1:3220/html/ios.html?screen=primaryScreen&state=with-overrides
- interact with any sub-page, and then use the back button in the browser

---

## Before (this shows the bug)

https://github.com/user-attachments/assets/da9f44ea-9ff8-49ec-8a45-2a4a15d7c374


## After (this is fixed)

https://github.com/user-attachments/assets/d712b9a8-b782-42dc-adc7-040f238cab40

https://github.com/user-attachments/assets/dd5232b9-73ed-48d2-a400-4349ab28a873


