### PR TITLE
windows: support translations

### DIFF
--- a/build/app/public/js/base.js
+++ b/build/app/public/js/base.js
@@ -4807,7 +4807,8 @@
         permissions: z3.array(z3.unknown()).optional(),
         certificates: z3.array(z3.unknown()).optional(),
         cookiePromptManagementStatus: cookiePromptManagementStatusSchema.optional(),
-        isInvalidCert: z3.boolean().optional()
+        isInvalidCert: z3.boolean().optional(),
+        localeSettings: localeSettingsSchema.optional()
       });
       toggleReportScreenSchema = z3.object({
         data: z3.array(toggleReportScreenDataItemSchema)
@@ -10252,7 +10253,7 @@
   };
 
   // node_modules/@formatjs/icu-messageformat-parser/lib/date-time-pattern-generator.js
-  function getBestPattern(skeleton, locale3) {
+  function getBestPattern(skeleton, locale4) {
     var skeletonCopy = "";
     for (var patternPos = 0; patternPos < skeleton.length; patternPos++) {
       var patternChar = skeleton.charAt(patternPos);
@@ -10265,7 +10266,7 @@
         var hourLen = 1 + (extraLength & 1);
         var dayPeriodLen = extraLength < 2 ? 1 : 3 + (extraLength >> 1);
         var dayPeriodChar = "a";
-        var hourChar = getDefaultHourSymbolFromLocale(locale3);
+        var hourChar = getDefaultHourSymbolFromLocale(locale4);
         if (hourChar == "H" || hourChar == "k") {
           dayPeriodLen = 0;
         }
@@ -10283,12 +10284,12 @@
     }
     return skeletonCopy;
   }
-  function getDefaultHourSymbolFromLocale(locale3) {
-    var hourCycle = locale3.hourCycle;
+  function getDefaultHourSymbolFromLocale(locale4) {
+    var hourCycle = locale4.hourCycle;
     if (hourCycle === void 0 && // @ts-ignore hourCycle(s) is not identified yet
-    locale3.hourCycles && // @ts-ignore
-    locale3.hourCycles.length) {
-      hourCycle = locale3.hourCycles[0];
+    locale4.hourCycles && // @ts-ignore
+    locale4.hourCycles.length) {
+      hourCycle = locale4.hourCycles[0];
     }
     if (hourCycle) {
       switch (hourCycle) {
@@ -10304,10 +10305,10 @@
           throw new Error("Invalid hourCycle");
       }
     }
-    var languageTag = locale3.language;
+    var languageTag = locale4.language;
     var regionTag;
     if (languageTag !== "root") {
-      regionTag = locale3.maximize().region;
+      regionTag = locale4.maximize().region;
     }
     var hourCycles = timeData[regionTag || ""] || timeData[languageTag || ""] || timeData["".concat(languageTag, "-001")] || timeData["001"];
     return hourCycles[0];
@@ -14577,13 +14578,15 @@
   var protections3;
   var isPendingUpdates3;
   var parentEntity3;
+  var locale3;
   var combineSources3 = () => ({
     tab: Object.assign(
       {},
       trackerBlockingData3 || {},
       {
         isPendingUpdates: isPendingUpdates3,
-        parentEntity: parentEntity3
+        parentEntity: parentEntity3,
+        locale: locale3
       },
       permissionsData3 ? { permissions: permissionsData3 } : {},
       certificateData3 ? { certificate: certificateData3 } : {}
@@ -14605,6 +14608,7 @@
     permissionsData3 = viewModel.permissions || [];
     certificateData3 = viewModel.certificates || [];
     protections3 = viewModel.protections;
+    locale3 = viewModel.localeSettings?.locale;
     trackerBlockingData3 = createTabData(viewModel.tabUrl, upgradedHttps3, viewModel.protections, viewModel.rawRequestData);
     trackerBlockingData3.cookiePromptManagementStatus = viewModel.cookiePromptManagementStatus;
     trackerBlockingData3.isInvalidCert = viewModel.isInvalidCert;

--- a/schema/__generated__/schema.parsers.mjs
+++ b/schema/__generated__/schema.parsers.mjs
@@ -294,7 +294,8 @@ export const windowsViewModelSchema = z.object({
     permissions: z.array(z.unknown()).optional(),
     certificates: z.array(z.unknown()).optional(),
     cookiePromptManagementStatus: cookiePromptManagementStatusSchema.optional(),
-    isInvalidCert: z.boolean().optional()
+    isInvalidCert: z.boolean().optional(),
+    localeSettings: localeSettingsSchema.optional()
 });
 
 export const toggleReportScreenSchema = z.object({

--- a/schema/__generated__/schema.types.ts
+++ b/schema/__generated__/schema.types.ts
@@ -451,6 +451,7 @@ export interface WindowsViewModel {
   certificates?: unknown[];
   cookiePromptManagementStatus?: CookiePromptManagementStatus;
   isInvalidCert?: boolean;
+  localeSettings?: LocaleSettings;
 }
 /**
  * This describes the fields needed for the dashboard to display the status of CPM (Cookie Prompt Management)

--- a/schema/windows-view-model.json
+++ b/schema/windows-view-model.json
@@ -28,6 +28,9 @@
         "cookiePromptManagementStatus": { "$ref": "./cookie-prompt-management-status.json" },
         "isInvalidCert": {
             "type": "boolean"
+        },
+        "localeSettings": {
+            "$ref": "locale.json"
         }
     }
 }

--- a/shared/js/browser/windows-communication.js
+++ b/shared/js/browser/windows-communication.js
@@ -58,6 +58,9 @@ let protections
 let isPendingUpdates
 let parentEntity
 
+/** @type {string | undefined} */
+let locale
+
 const combineSources = () => ({
     tab: Object.assign(
         {},
@@ -65,6 +68,7 @@ const combineSources = () => ({
         {
             isPendingUpdates,
             parentEntity,
+            locale,
         },
         permissionsData ? { permissions: permissionsData } : {},
         certificateData ? { certificate: certificateData } : {}
@@ -103,6 +107,7 @@ function handleViewModelUpdate(viewModel) {
     permissionsData = viewModel.permissions || []
     certificateData = viewModel.certificates || []
     protections = viewModel.protections
+    locale = viewModel.localeSettings?.locale
 
     trackerBlockingData = createTabData(viewModel.tabUrl, upgradedHttps, viewModel.protections, viewModel.rawRequestData)
     trackerBlockingData.cookiePromptManagementStatus = viewModel.cookiePromptManagementStatus

--- a/shared/js/ui/views/tests/generate-data.mjs
+++ b/shared/js/ui/views/tests/generate-data.mjs
@@ -332,6 +332,7 @@ export class MockData {
                 certificates: this.certificate,
                 cookiePromptManagementStatus: this.cookiePromptManagementStatus,
                 isInvalidCert: this.isInvalidCert,
+                localeSettings: this.localeSettings,
             },
         }
     }


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

## Description:

Adding this structure to the view model on Windows will enable translations.

> [!NOTE]
> This is a none-breaking change.

```json
{ 
    ...,
   "localeSettings": { "locale": "en" }
}
```
