### PR TITLE
ci: add release protection

### DIFF
--- a/.github/workflows/release-protection.yml
+++ b/.github/workflows/release-protection.yml
@@ -1,37 +1,37 @@
 name: Delete manually created release
 
 on:
-  release:
-    types:
-      - created
+    release:
+        types:
+            - created
 
 jobs:
-  validate-release:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out the repository
-        uses: actions/checkout@v3
+    validate-release:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Check out the repository
+              uses: actions/checkout@v3
 
-      - name: Delete Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Deleting release: ${{ github.event.release.tag_name }}"
-          gh release delete ${{ github.event.release.tag_name }} --yes
+            - name: Delete Release
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  echo "Deleting release: ${{ github.event.release.tag_name }}"
+                  gh release delete ${{ github.event.release.tag_name }} --yes
 
-      - name: Delete the release and tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Deleting tag: ${{ github.event.release.tag_name }}"
-          git tag -d ${{ github.event.release.tag_name }}
-          git push origin --delete ${{ github.event.release.tag_name }}
+            - name: Delete the release and tag
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  echo "Deleting tag: ${{ github.event.release.tag_name }}"
+                  git tag -d ${{ github.event.release.tag_name }}
+                  git push origin --delete ${{ github.event.release.tag_name }}
 
-      - name: Why was this release deleted?
-        run: |
-          cat <<EOF
-          Our release process commits assets to the 'releases' branch - and that has to occur before the 
-          git tag is created. Because of that fact, we need to prevent anyone from creating a release in the GitHub UI.
-          
-          Instead, use the release workflow.
-          EOF
+            - name: Why was this release deleted?
+              run: |
+                  cat <<EOF
+                  Our release process commits assets to the 'releases' branch - and that has to occur before the 
+                  git tag is created. Because of that fact, we need to prevent anyone from creating a release in the GitHub UI.
+
+                  Instead, use the release workflow.
+                  EOF

--- a/.github/workflows/release-protection.yml
+++ b/.github/workflows/release-protection.yml
@@ -1,0 +1,37 @@
+name: Delete manually created release
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  validate-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+
+      - name: Delete Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Deleting release: ${{ github.event.release.tag_name }}"
+          gh release delete ${{ github.event.release.tag_name }} --yes
+
+      - name: Delete the release and tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Deleting tag: ${{ github.event.release.tag_name }}"
+          git tag -d ${{ github.event.release.tag_name }}
+          git push origin --delete ${{ github.event.release.tag_name }}
+
+      - name: Why was this release deleted?
+        run: |
+          cat <<EOF
+          Our release process commits assets to the 'releases' branch - and that has to occur before the 
+          git tag is created. Because of that fact, we need to prevent anyone from creating a release in the GitHub UI.
+          
+          Instead, use the release workflow.
+          EOF


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

https://app.asana.com/0/1200835453786799/1209020109305112/f

<!-- Optional fields
**CC:**
**Depends on:**
-->

## Description:

Prevent Releases from being created from the GitHub UI

This workflow will only run when a release is created from the GitHub UI - the release and git tag will be deleted.
