### PR TITLE
Fire message when invoking breakage form

### DIFF
--- a/integration-tests/Mocks.js
+++ b/integration-tests/Mocks.js
@@ -80,8 +80,30 @@ export class Mocks {
     }
 
     async calledForReportBreakageFormShown() {
-        const calls = await this.outgoing();
-        expect(calls).toEqual([['privacyDashboardReportBrokenSiteShown', {}]]);
+        if (this.platform.name === 'ios' || this.platform.name === 'macos') {
+            const calls = await this.outgoing();
+            expect(calls).toMatchObject([['privacyDashboardReportBrokenSiteShown', {}]]);
+            return;
+        }
+
+        if (this.platform.name === 'windows') {
+            const calls = await this.outgoing({
+                names: ['ReportBrokenSiteShown'],
+            });
+            expect(calls).toMatchObject([
+                [
+                    'ReportBrokenSiteShown',
+                    {
+                        Feature: 'PrivacyDashboard',
+                        Name: 'ReportBrokenSiteShown',
+                        Data: {},
+                    },
+                ],
+            ]);
+            return;
+        }
+
+        throw new Error('unreachable. mockCalledForReportBreakageFormShown must be handled');
     }
 
     async calledForSendToggleReport() {

--- a/integration-tests/Mocks.js
+++ b/integration-tests/Mocks.js
@@ -75,7 +75,7 @@ export class Mocks {
             return;
         }
         if (this.platform.name === 'ios') {
-            expect(calls).toMatchObject([['privacyDashboardShowReportBrokenSite', {}]]);
+            expect(calls).toMatchObject([['privacyDashboardReportBrokenSiteShown', {}]]);
         }
     }
 

--- a/integration-tests/Mocks.js
+++ b/integration-tests/Mocks.js
@@ -80,6 +80,12 @@ export class Mocks {
     }
 
     async calledForReportBreakageFormShown() {
+        if (this.platform.name === 'android') {
+            const calls = await this.outgoing({ names: ['reportBrokenSiteShown'] });
+            expect(calls).toMatchObject([['reportBrokenSiteShown', undefined]]);
+            return;
+        }
+
         if (this.platform.name === 'ios' || this.platform.name === 'macos') {
             const calls = await this.outgoing();
             expect(calls).toMatchObject([['privacyDashboardReportBrokenSiteShown', {}]]);

--- a/integration-tests/Mocks.js
+++ b/integration-tests/Mocks.js
@@ -87,7 +87,10 @@ export class Mocks {
         }
 
         if (this.platform.name === 'ios' || this.platform.name === 'macos') {
-            const calls = await this.outgoing();
+            const calls = await this.outgoing({
+                names: ['privacyDashboardReportBrokenSiteShown'],
+            });
+
             expect(calls).toMatchObject([['privacyDashboardReportBrokenSiteShown', {}]]);
             return;
         }

--- a/integration-tests/Mocks.js
+++ b/integration-tests/Mocks.js
@@ -79,6 +79,11 @@ export class Mocks {
         }
     }
 
+    async calledForReportBreakageFormShown() {
+        const calls = await this.outgoing();
+        expect(calls).toEqual([['privacyDashboardReportBrokenSiteShown', {}]]);
+    }
+
     async calledForSendToggleReport() {
         if (this.platform.name === 'android') {
             const calls = await this.outgoing({ names: ['sendToggleReport'] });

--- a/integration-tests/android.spec-int.js
+++ b/integration-tests/android.spec-int.js
@@ -54,6 +54,21 @@ test.describe('Protections toggle', () => {
 });
 
 test.describe('breakage form', () => {
+    test('sends message when breakage form is triggered from primary screen', async ({ page }) => {
+        /** @type {DashboardPage} */
+        const dash = await DashboardPage.android(page);
+        await dash.addState([testDataStates['webBreakageForm-enabled']]);
+        await dash.clicksWebsiteNotWorking();
+        await dash.mocks.calledForReportBreakageFormShown();
+    });
+
+    test('sends message when breakage form is triggered from app menu', async ({ page }) => {
+        /** @type {DashboardPage} */
+        const dash = await DashboardPage.android(page, { screen: 'breakageForm' });
+        await dash.addState([testDataStates.google]);
+        await dash.mocks.calledForReportBreakageFormShown();
+    });
+
     test('uses native breakage form', async ({ page }) => {
         const dash = await DashboardPage.android(page);
         await dash.addState([testDataStates['webBreakageForm-disabled']]);

--- a/integration-tests/ios.spec-int.js
+++ b/integration-tests/ios.spec-int.js
@@ -129,6 +129,21 @@ test.describe('cookie prompt management', () => {
 });
 
 test.describe('breakage form', () => {
+    test('sends message when breakage form is triggered from primary screen', async ({ page }) => {
+        /** @type {DashboardPage} */
+        const dash = await DashboardPage.webkit(page, { platform: 'ios', opener: 'dashboard' });
+        await dash.addState([testDataStates.google]);
+        await dash.clicksWebsiteNotWorking();
+        await dash.mocks.calledForReportBreakageFormShown();
+    });
+
+    test('sends message when breakage form is triggered from app menu', async ({ page }) => {
+        /** @type {DashboardPage} */
+        const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'ios' });
+        await dash.addState([testDataStates.google]);
+        await dash.mocks.calledForReportBreakageFormShown();
+    });
+
     test('shows breakage form on category selection screen only', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'ios' });

--- a/integration-tests/macos.spec-int.js
+++ b/integration-tests/macos.spec-int.js
@@ -90,6 +90,21 @@ test('allowed first party requests', async ({ page }) => {
 });
 
 test.describe('breakage form', () => {
+    test('sends message when breakage form is triggered from primary screen', async ({ page }) => {
+        /** @type {DashboardPage} */
+        const dash = await DashboardPage.webkit(page, { platform: 'macos', opener: 'dashboard' });
+        await dash.addState([testDataStates.google]);
+        await dash.clicksWebsiteNotWorking();
+        await dash.mocks.calledForReportBreakageFormShown();
+    });
+
+    test('sends message when breakage form is triggered from app menu', async ({ page }) => {
+        /** @type {DashboardPage} */
+        const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'macos' });
+        await dash.addState([testDataStates.google]);
+        await dash.mocks.calledForReportBreakageFormShown();
+    });
+
     test('shows breakage form on category selection screen only', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'macos' });

--- a/integration-tests/windows.spec-int.js
+++ b/integration-tests/windows.spec-int.js
@@ -12,6 +12,21 @@ test.describe('initial page data', () => {
 });
 
 test.describe('breakage form', () => {
+    test('sends message when breakage form is triggered from primary screen', async ({ page }) => {
+        /** @type {DashboardPage} */
+        const dash = await DashboardPage.windows(page);
+        await dash.addState([testDataStates.google]);
+        await dash.clicksWebsiteNotWorking();
+        await dash.mocks.calledForReportBreakageFormShown();
+    });
+
+    test('sends message when breakage form is triggered from app menu', async ({ page }) => {
+        /** @type {DashboardPage} */
+        const dash = await DashboardPage.windows(page, { screen: 'breakageForm' });
+        await dash.addState([testDataStates.google]);
+        await dash.mocks.calledForReportBreakageFormShown();
+    });
+
     test('shows breakage form on category selection screen only', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.windows(page, { screen: 'breakageForm' });

--- a/shared/js/browser/android-communication.js
+++ b/shared/js/browser/android-communication.js
@@ -28,6 +28,7 @@ import {
     setupColorScheme,
     SubmitBrokenSiteReportMessage,
     ShowNativeFeedback,
+    ReportBrokenSiteShown,
 } from './common.js';
 import { createTabData } from './utils/request-details.mjs';
 import invariant from 'tiny-invariant';
@@ -383,6 +384,15 @@ export class PrivacyDashboardJavascriptInterface {
         invariant(window.PrivacyDashboard?.showNativeFeedback, 'showNativeFeedback missing');
         window.PrivacyDashboard.showNativeFeedback();
     }
+
+    /**
+     * {@inheritDoc common.reportBrokenSiteShown}
+     * @type {import("./common.js").reportBrokenSiteShown}
+     */
+    reportBrokenSiteShown() {
+        invariant(window.PrivacyDashboard?.reportBrokenSiteShown, 'reportBrokenSiteShown missing');
+        window.PrivacyDashboard.reportBrokenSiteShown();
+    }
 }
 
 /**
@@ -418,7 +428,7 @@ async function fetchAndroid(message) {
     }
 
     if (message instanceof CheckBrokenSiteReportHandledMessage) {
-        privacyDashboardApi.showBreakageForm();
+        privacyDashboardApi.showBreakageForm(); // TODO: Check what happens
         return true; // Return true to prevent HTML form from showing
     }
 
@@ -454,6 +464,10 @@ async function fetchAndroid(message) {
 
     if (message instanceof ShowNativeFeedback) {
         return privacyDashboardApi.showNativeFeedback();
+    }
+
+    if (message instanceof ReportBrokenSiteShown) {
+        return privacyDashboardApi.reportBrokenSiteShown();
     }
 
     console.warn('unhandled message', message);

--- a/shared/js/browser/android-communication.js
+++ b/shared/js/browser/android-communication.js
@@ -428,7 +428,9 @@ async function fetchAndroid(message) {
     }
 
     if (message instanceof CheckBrokenSiteReportHandledMessage) {
-        privacyDashboardApi.showBreakageForm(); // TODO: Check what happens
+        // This method is kept here for now so that Android can toggle the native breakage form if needed.
+        // On the Android side, this is behind a feature flag and will noop when the web-based form is enabled
+        privacyDashboardApi.showBreakageForm();
         return true; // Return true to prevent HTML form from showing
     }
 

--- a/shared/js/browser/common.js
+++ b/shared/js/browser/common.js
@@ -331,6 +331,13 @@ export function showNativeFeedback() {
 }
 
 /**
+ * Sent when the user invokes the site breakage form
+ */
+export function reportBrokenSiteShown() {
+    throw new Error('base impl');
+}
+
+/**
  * @param {import('../../../schema/__generated__/schema.types').Search} options
  */
 export function search(options) {}
@@ -435,6 +442,12 @@ export class OpenOptionsMessage extends Msg {}
  * an alert because the form description was required, but missing
  */
 export class ShowNativeFeedback extends Msg {}
+
+/**
+ * Use this message to indicate that the user has invoked the
+ * site breakage report flow
+ */
+export class ReportBrokenSiteShown extends Msg {}
 
 /**
  * Use this message to indicate that an internal navigation occurred

--- a/shared/js/browser/ios-communication.js
+++ b/shared/js/browser/ios-communication.js
@@ -86,7 +86,7 @@ export function privacyDashboardTelemetrySpan(args) {
  */
 async function fetch(message) {
     if (message instanceof CheckBrokenSiteReportHandledMessage) {
-        privacyDashboardShowReportBrokenSite({});
+        // privacyDashboardShowReportBrokenSite({});
         return false; // Return true to prevent HTML form from showing
     }
     if (message instanceof ShowNativeFeedback) {

--- a/shared/js/browser/ios-communication.js
+++ b/shared/js/browser/ios-communication.js
@@ -86,7 +86,6 @@ export function privacyDashboardTelemetrySpan(args) {
  */
 async function fetch(message) {
     if (message instanceof CheckBrokenSiteReportHandledMessage) {
-        // privacyDashboardShowReportBrokenSite({});
         return false; // Return true to prevent HTML form from showing
     }
     if (message instanceof ShowNativeFeedback) {

--- a/shared/js/browser/macos-communication.js
+++ b/shared/js/browser/macos-communication.js
@@ -38,6 +38,7 @@ import {
     SubmitBrokenSiteReportMessage,
     UpdatePermissionMessage,
     ShowNativeFeedback,
+    ReportBrokenSiteShown,
 } from './common.js';
 import { createTabData } from './utils/request-details.mjs';
 
@@ -271,7 +272,22 @@ export function privacyDashboardSetPermission(params) {
 }
 
 /**
- * @category Webkit Message Handler
+ * Notifies the app that the site breakage form has been invoked
+ *
+ * @category Webkit Message Handlers
+ * @param {{}} args - An empty object to keep the `webkit` message handlers happy
+ * @example
+ * ```js
+ * window.webkit.messageHandlers.privacyDashboardReportBrokenSiteShown.postMessage(args)
+ * ```
+ */
+export function privacyDashboardReportBrokenSiteShown(args) {
+    invariant(window.webkit?.messageHandlers, 'webkit.messageHandlers required');
+    window.webkit.messageHandlers.privacyDashboardReportBrokenSiteShown.postMessage(args);
+}
+
+/**
+ * @category Webkit Message Handlers
  * @example
  *
  * When the Dashboard loads, it will call this message handler...
@@ -441,6 +457,11 @@ async function fetch(message) {
 
     if (message instanceof ShowNativeFeedback) {
         privacyDashboardShowNativeFeedback({});
+        return false; // Return true to prevent HTML form from showing
+    }
+
+    if (message instanceof ReportBrokenSiteShown) {
+        privacyDashboardReportBrokenSiteShown({});
         return false; // Return true to prevent HTML form from showing
     }
 }

--- a/shared/js/browser/utils/communication-mocks.mjs
+++ b/shared/js/browser/utils/communication-mocks.mjs
@@ -135,6 +135,11 @@ export function webkitMockApis({ messages = {} }) {
                         window.__playwright.mocks.outgoing.push(['privacyDashboardShowReportBrokenSite', arg]);
                     },
                 },
+                privacyDashboardReportBrokenSiteShown: {
+                    postMessage: (arg) => {
+                        window.__playwright.mocks.outgoing.push(['privacyDashboardReportBrokenSiteShown', arg]);
+                    },
+                },
                 privacyDashboardOpenUrlInNewTab: {
                     postMessage: (arg) => {
                         window.__playwright.mocks.outgoing.push(['privacyDashboardOpenUrlInNewTab', arg]);

--- a/shared/js/browser/utils/communication-mocks.mjs
+++ b/shared/js/browser/utils/communication-mocks.mjs
@@ -260,6 +260,9 @@ export function mockAndroidApis({ messages = {} }) {
             showNativeFeedback() {
                 window.__playwright.mocks.outgoing.push(['showNativeFeedback']);
             },
+            reportBrokenSiteShown() {
+                window.__playwright.mocks.outgoing.push(['reportBrokenSiteShown']);
+            },
         };
     } catch (e) {
         console.error("❌couldn't set up mocks");

--- a/shared/js/browser/windows-communication.js
+++ b/shared/js/browser/windows-communication.js
@@ -51,6 +51,7 @@ import {
     SeeWhatIsSent,
     SendToggleBreakageReport,
     ShowNativeFeedback,
+    ReportBrokenSiteShown,
 } from './common.js';
 import { createTabData } from './utils/request-details.mjs';
 
@@ -170,6 +171,11 @@ async function fetch(message) {
 
     if (message instanceof ShowNativeFeedback) {
         showNativeFeedback();
+        return;
+    }
+
+    if (message instanceof ReportBrokenSiteShown) {
+        reportBrokenSiteShown();
         return;
     }
 
@@ -485,6 +491,10 @@ function seeWhatIsSent() {
 
 function showNativeFeedback() {
     windowsPostMessage('ShowNativeFeedback', {});
+}
+
+function reportBrokenSiteShown() {
+    windowsPostMessage('ReportBrokenSiteShown', {});
 }
 
 export { fetch, backgroundMessage, getBackgroundTabData, firstRenderComplete };

--- a/types.ts
+++ b/types.ts
@@ -65,6 +65,7 @@ interface Window {
         rejectToggleReport: () => void;
         seeWhatIsSent: () => void;
         showNativeFeedback: () => void;
+        reportBrokenSiteShown: () => void;
     };
     /**
      * This is set in Playwright tests

--- a/types.ts
+++ b/types.ts
@@ -5,6 +5,7 @@ interface WebkitMessageHandlers {
     privacyDashboardOpenUrlInNewTab?: any;
     privacyDashboardSetSize?: any;
     privacyDashboardShowReportBrokenSite?: any;
+    privacyDashboardReportBrokenSiteShown?: any;
     privacyDashboardClose?: any;
     privacyDashboardSetProtection?: {
         postMessage: (params: import('./schema/__generated__/schema.types').SetProtectionParams) => void;

--- a/v2/data-provider.js
+++ b/v2/data-provider.js
@@ -7,6 +7,7 @@ import { i18n } from '../shared/js/ui/base/localize';
 import { createPlatformFeatures, FeatureSettings, PlatformFeatures } from '../shared/js/ui/platform-features.mjs';
 import {
     CloseMessage,
+    ReportBrokenSiteShown,
     SetListsMessage,
     ShowNativeFeedback,
     SubmitBrokenSiteReportMessage,
@@ -457,6 +458,15 @@ export function useShowNativeFeedback() {
     const nav = useNav();
     return useCallback(() => {
         const msg = new ShowNativeFeedback();
+        fetcher(msg).catch(console.error);
+    }, [nav]);
+}
+
+export function useReportBrokenSiteShown() {
+    const fetcher = useFetcher();
+    const nav = useNav();
+    return useCallback(() => {
+        const msg = new ReportBrokenSiteShown();
         fetcher(msg).catch(console.error);
     }, [nav]);
 }

--- a/v2/screens/breakage-form-screen.jsx
+++ b/v2/screens/breakage-form-screen.jsx
@@ -2,17 +2,25 @@
 import { h } from 'preact';
 import cn from 'classnames';
 import { platform } from '../../shared/js/browser/communication.js';
-import { useMemo, useState, useRef, useContext, useLayoutEffect } from 'preact/hooks';
+import { useMemo, useState, useRef, useContext, useLayoutEffect, useEffect } from 'preact/hooks';
 import { SecondaryTopNavAlt, Title } from '../components/top-nav';
 import { Nav, NavItem } from '../components/nav';
 import { KeyInsightsMain } from '../components/key-insights';
 import { useNav } from '../navigation';
-import { useData, useFeatures, useSendReport, useShowNativeFeedback, useFetcher, useClose } from '../data-provider';
 import { ns } from '../../shared/js/ui/base/localize';
 import { Stack } from '../../shared/js/ui/components/stack';
 import { createBreakageFeaturesFrom, defaultCategories } from '../breakage-categories';
 import { BreakageFormContext, BreakageFormProvider } from '../components/breakage-form-provider.jsx';
 import { namedString } from '../../shared/data/text.js';
+import {
+    useData,
+    useFeatures,
+    useSendReport,
+    useShowNativeFeedback,
+    useFetcher,
+    useClose,
+    useReportBrokenSiteShown,
+} from '../data-provider';
 
 /** @typedef {'choice-problem'|'choice-category'|'form'|'success'} BreakagePageId */
 
@@ -20,6 +28,11 @@ export function BreakagePrimaryScreen() {
     const description = ns.report('selectTheCategoryType.title');
     const { push } = useNav();
     const { tab } = useData();
+    const reportBrokenSiteShown = useReportBrokenSiteShown();
+
+    useEffect(() => {
+        reportBrokenSiteShown();
+    }, []);
 
     const showNativeFeedback = useShowNativeFeedback();
     return (


### PR DESCRIPTION
Asana: https://app.asana.com/0/0/1209180773957103/f

**Reviewer:** @shakyShane 

## Description:

Adds a new `privacyDashboardReportBrokenSiteShown` comms method to notify native that the breakage form has been shown
 
## Steps to test this PR:

1. Open the [preview](https://deploy-preview-302--ddgdash.netlify.app/app-debug/html/iframe?state=webBreakageForm-enabled&platforms=android%2Cios%2Cmacos%2Cwindows)
2. Open the console
3. Click on “Report a problem with this site” (Android / iOS / macOS / Windows)
4. Confirm that the `ReportBrokenSiteShown` message has been fired
