### PR TITLE
windows: send a ping

### DIFF
--- a/integration-tests/DashboardPage.js
+++ b/integration-tests/DashboardPage.js
@@ -362,6 +362,10 @@ export class DashboardPage {
         return results;
     }
 
+    async sendsPing() {
+        await this.mocks.sentPing();
+    }
+
     async submitBreakageForm() {
         await this.page.getByRole('button', { name: 'Send Report' }).click();
     }

--- a/integration-tests/Mocks.js
+++ b/integration-tests/Mocks.js
@@ -291,6 +291,10 @@ export class Mocks {
         throw new Error('unreachable. mockCalledForNativeFeedback must be handled');
     }
 
+    async sentPing() {
+        await this.outgoing({ names: ['Ping'] });
+    }
+
     async calledForSubmitBreakageForm({ category = '', description = '' }) {
         if (this.platform.name === 'android') {
             const out = await this.outgoing({ names: ['submitBrokenSiteReport'] });

--- a/integration-tests/windows.spec-int.js
+++ b/integration-tests/windows.spec-int.js
@@ -8,6 +8,7 @@ test.describe('initial page data', () => {
         const dash = await DashboardPage.windows(page);
         await dash.addState([testDataStates.protectionsOn]);
         await dash.showsPrimaryScreen();
+        await dash.sendsPing();
     });
 });
 

--- a/shared/js/browser/windows-communication.js
+++ b/shared/js/browser/windows-communication.js
@@ -411,6 +411,7 @@ export function setup() {
     globalThis.windowsInteropAddEventListener('message', (event) => {
         if (event.data.Name) handleIncomingMessage(event.data);
     });
+    windowsPostMessage('Ping', {});
     setupMutationObserver((height) => {
         SetSize({ height });
     });


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @mgurgel 

<!-- Optional fields
**CC:**
**Depends on:**
-->

## Description:

Sends a `Ping` message to indicate JS readiness. (NOTE: this is a workaround for the legacy messaging system)

## Steps to test this PR:

- [x] tested by Boli in the Windows App
