### PR TITLE
Ignore call to ReportBrokenSiteShown on the extension

### DIFF
--- a/shared/js/browser/browser-communication.js
+++ b/shared/js/browser/browser-communication.js
@@ -21,6 +21,7 @@ import {
     OpenOptionsMessage,
     RefreshEmailAliasMessage,
     RejectToggleBreakageReport,
+    ReportBrokenSiteShown,
     SearchMessage,
     SeeWhatIsSent,
     SendToggleBreakageReport,
@@ -167,6 +168,11 @@ export async function fetch(message) {
     }
     if (message instanceof SeeWhatIsSent) {
         return seeWhatIsSent();
+    }
+    /* This fires a pixel when showing the breakage form on native platforms.
+       On the extension, it's currently ignored. */
+    if (message instanceof ReportBrokenSiteShown) {
+        return false;
     }
     return Promise.reject(new Error('unhandled message: ' + JSON.stringify(message)));
 }


### PR DESCRIPTION
Asana: https://app.asana.com/0/1206594217596623/1209264342798609/f

**Reviewer:** @shakyShane 

## Description:

- Explicitly ignores the ReportBrokenSiteShown on the extension

## Steps to test this PR:

1. Visit the preview
2. Click on “Report 
