### PR TITLE
fix playwright tests with better mock separation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
                   path: playwright-report/
                   retention-days: 30
             - if: ${{ failure() && steps.screenshot_tests.conclusion == 'failure' }}
-              run: npm run test.int -- --grep @screenshots --update-snapshots
+              run: npm run test.int -- --grep @screenshots --update-snapshots --last-failed
             - if: ${{ failure() && steps.screenshot_tests.conclusion == 'failure' }}
               name: Upload screens
               uses: actions/upload-artifact@v4

--- a/.github/workflows/update-snapshots.yml
+++ b/.github/workflows/update-snapshots.yml
@@ -4,7 +4,7 @@ on:
     workflow_dispatch:
         inputs:
             pr_number:
-                description: 'Pull Request Number'
+                description: 'Pull Request Number (Warning: This action will push a commit to the referenced PR)'
                 required: true
                 type: string
 
@@ -17,25 +17,59 @@ jobs:
         name: Update PR Snapshots
         runs-on: macos-latest
         steps:
-            - name: Checkout PR
+            - uses: actions/checkout@v3
+            - name: Checkout PR ${{ github.event.inputs.pr_number }}
               if: github.event_name == 'workflow_dispatch'
               run: gh pr checkout ${{ github.event.inputs.pr_number }}
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-            - name: Run command
-              if: github.event_name == 'workflow_dispatch'
+            - name: Use Node.js from .nvmrc
+              uses: actions/setup-node@v3
+              with:
+                  node-version-file: '.nvmrc'
+
+            - name: Cache node modules
+              id: cache-npm
+              uses: actions/cache@v3
+              env:
+                  cache-name: cache-node-modules
+              with:
+                  path: node_modules
+                  key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Build all
+              run: npm run build && npm run build.debug
+
+            - name: Fetch fonts
+              run: npm run fetch-fonts
+
+            - name: Install Playwright Browsers
+              run: npx playwright install --with-deps
+
+            - name: Run Screenshot tests
+              id: screenshot_tests
+              run: npm run test.int -- screenshots.js --grep @screenshots
+
+            - if: ${{ failure() && steps.screenshot_tests.conclusion == 'success' }}
               run: |
-                  echo "Running A command here command..."
+                  echo "nothing to update - tests all passed"
 
-            # Step 5: Commit and push changes back to the PR branch
+            - name: Re-Running Playwright to update snapshots
+              id: screenshot_tests_update
+              if: ${{ failure() && steps.screenshot_tests.conclusion == 'failure' }}
+              run: npm run test.int -- screenshots.js --grep @screenshots --update-snapshots --last-failed
 
-#      - name: Commit and push changes
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#        run: |
-#          git config user.name "github-actions[bot]"
-#          git config user.email "github-actions[bot]@users.noreply.github.com"
-#          git add .
-#          git commit -m "Automated updates from GitHub Actions"
-#          git push origin ${{ env.PR_BRANCH }}
+            - name: Commit the updated files to the PR branch
+              if: ${{ failure() && steps.screenshot_tests_update.conclusion == 'success' }}
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add integration-tests/*
+                  git commit -m "Updated snapshots via workflow"
+                  git push origin HEAD

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ build/
 build/app_backup
 bslive.yml
 .vscode
+/json-reports

--- a/integration-tests/DashboardPage.js
+++ b/integration-tests/DashboardPage.js
@@ -2,7 +2,7 @@ import { expect } from '@playwright/test';
 import { forwardConsole, playTimeline } from './helpers';
 import { Mocks } from './Mocks';
 import { Nav } from './Nav';
-import { testDataStates } from '../shared/js/ui/views/tests/states-with-fixtures';
+import { testDataStates } from './utils/states-with-fixtures';
 import { mockBrowserApis } from '../shared/js/browser/utils/communication-mocks.mjs';
 import { Extension } from './Extension';
 import toggleReportScreen from '../schema/__fixtures__/toggle-report-screen.json';
@@ -490,7 +490,8 @@ export class DashboardPage {
      * @param {{ telemetry?: boolean }} [options]
      */
     async selectsCategory(text, category, options = { telemetry: false }) {
-        await this.page.getByLabel(text).click();
+        // await this.page.pause();
+        await this.page.getByLabel(text).click({ timeout: 5000 });
 
         if (options.telemetry) {
             await this.mocks.didSendTelemetry({
@@ -829,6 +830,21 @@ export class DashboardPage {
 
     async showsBreakageForm() {
         await this.page.getByText('Submitting an anonymous').waitFor({ timeout: 5000 });
+    }
+
+    // todo: remove
+    async waitForRouterToSettle() {
+        const { page } = this;
+        // wait for it to start animating
+        await page.waitForFunction(() => {
+            const element = document.getElementById('popup-container');
+            return element && element.classList.contains('sliding-subview-v2--animating');
+        });
+        // then wait for it to finish
+        await page.waitForFunction(() => {
+            const element = document.getElementById('popup-container');
+            return element && !element.classList.contains('sliding-subview-v2--animating');
+        });
     }
 
     async skipsToBreakageFormWhenDisliked() {

--- a/integration-tests/Extension.js
+++ b/integration-tests/Extension.js
@@ -32,7 +32,7 @@ export class Extension {
         await page.evaluate(() => {
             window.__playwright.onDisconnect?.();
         });
-        const callCountAfter = await this.dash.mocks.outgoing({ names: ['getToggleReportOptions'] });
+        const callCountAfter = await this.dash.mocks.waitFor({ name: 'getToggleReportOptions', count: 2 });
         expect(callCountAfter).toHaveLength(2);
     }
 

--- a/integration-tests/Mocks.js
+++ b/integration-tests/Mocks.js
@@ -65,6 +65,24 @@ export class Mocks {
         return values;
     }
 
+    /**
+     * @param {{name: string, count: number}} opts
+     * @returns {Promise<any[]>}
+     */
+    async waitFor(opts) {
+        await this.page.waitForFunction(
+            (opts) => {
+                const current = window.__playwright.mocks.outgoing;
+                return current.filter(([name]) => name === opts.name).length >= opts.count;
+            },
+            opts,
+            { timeout: 5000 }
+        );
+
+        const values = await this.page.evaluate(() => window.__playwright.mocks.outgoing);
+        return values.filter(([name]) => opts.name === name);
+    }
+
     async calledForShowBreakageForm() {
         // only on ios/android
         if (!['android', 'ios'].includes(this.platform.name)) return;

--- a/integration-tests/Nav.js
+++ b/integration-tests/Nav.js
@@ -16,6 +16,7 @@ export class Nav {
 
     async goesBackToPrimaryScreenFromBreakageScreen() {
         const { page } = this.dash;
+        await page.getByRole('textbox', { name: 'Please describe the issue you' }).waitFor({ timeout: 1000 });
         await page.getByTestId('subview-breakageFormFinalStep').getByLabel('Back', { exact: true }).click();
         await page.getByTestId('subview-breakageFormCategorySelection').getByLabel('Back', { exact: true }).click();
         await page.getByTestId('subview-breakageForm').getByLabel('Back', { exact: true }).click();

--- a/integration-tests/android.spec-int.js
+++ b/integration-tests/android.spec-int.js
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { testDataStates } from '../shared/js/ui/views/tests/states-with-fixtures';
+import { testDataStates } from './utils/states-with-fixtures';
 import { DashboardPage } from './DashboardPage';
 import { toggleFlows } from './utils/common-flows';
 
@@ -197,6 +197,7 @@ test.describe('breakage form', () => {
     test('shows empty description warning', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.android(page, { screen: 'breakageForm' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.selectsCategory('Something else', 'other');
@@ -209,6 +210,7 @@ test.describe('breakage form', () => {
     test('submits form with description', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.android(page, { screen: 'breakageForm' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.selectsCategory('Something else', 'other');
@@ -274,8 +276,11 @@ test.describe('stack based router', () => {
         await dash.addState([testDataStates['webBreakageForm-enabled']]);
 
         await dash.clicksWebsiteNotWorking();
+        await dash.waitForRouterToSettle();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
+        await dash.waitForRouterToSettle();
         await dash.selectsCategory('Site layout broken', 'layout');
+        await dash.waitForRouterToSettle();
         await dash.nav.goesBackToPrimaryScreenFromBreakageScreen();
     });
     test('goes back and forward generally', async ({ page }) => {
@@ -360,6 +365,7 @@ test.describe('Android screenshots', { tag: '@screenshots' }, () => {
             test(name, async ({ page }) => {
                 await page.emulateMedia({ reducedMotion: 'reduce' });
                 const dash = await DashboardPage.android(page);
+                await dash.reducedMotion();
                 await dash.screenshotEachScreenForState(name, state);
             });
         }
@@ -374,6 +380,7 @@ test.describe('Android screenshots', { tag: '@screenshots' }, () => {
         for (const { name, state } of states) {
             test(name, async ({ page }) => {
                 const dash = await DashboardPage.android(page);
+                await dash.reducedMotion();
                 await dash.addState([state]);
                 await dash.showsPrimaryScreen();
                 await dash.screenshot(`${name}.png`);
@@ -400,6 +407,7 @@ test.describe('Android screenshots', { tag: '@screenshots' }, () => {
             });
             test('secondary screen', async ({ page }) => {
                 const dash = await DashboardPage.android(page);
+                await dash.reducedMotion();
                 await dash.addState([testDataStates['consent-managed-configurable']]);
                 await dash.viewCookiePromptManagement();
                 await dash.screenshot('consent-managed-configurable-secondary.png');
@@ -417,6 +425,7 @@ test.describe('Android screenshots', { tag: '@screenshots' }, () => {
             test('secondary screen', async ({ page }) => {
                 const dash = await DashboardPage.android(page);
                 await dash.addState([testDataStates['consent-managed-configurable-cosmetic']]);
+                await dash.reducedMotion();
                 await dash.viewCookiePromptManagement();
                 await dash.screenshot('consent-managed-configurable-secondary-cosmetic.png');
                 await dash.disableCookiesInSettings();

--- a/integration-tests/browser.spec-int.js
+++ b/integration-tests/browser.spec-int.js
@@ -302,7 +302,7 @@ test.describe('screenshots', { tag: '@screenshots' }, () => {
     const states = [
         { name: 'ad-attribution', state: testDataStates['ad-attribution'] },
         { name: 'new-entities', state: testDataStates['new-entities'] },
-        { name: 'upgraded+secure', state: testDataStates['upgraded+secure'] },
+        // { name: 'upgraded+secure', state: testDataStates['upgraded+secure'] },
         { name: 'google-off', state: testDataStates['google-off'] },
         { name: 'cnn', state: testDataStates.cnn },
         {

--- a/integration-tests/browser.spec-int.js
+++ b/integration-tests/browser.spec-int.js
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { testDataStates } from '../shared/js/ui/views/tests/states-with-fixtures';
+import { testDataStates } from './utils/states-with-fixtures';
 import { DashboardPage } from './DashboardPage';
 import { toggleFlows } from './utils/common-flows';
 import { forwardConsole } from './helpers';
@@ -25,6 +25,7 @@ test.describe('breakage form', () => {
             screen: 'breakageForm',
             randomisedCategories: 'false',
         });
+        await dash.reducedMotion();
         await dash.screenshot('category-type-selection.png');
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.screenshot('category-selection.png');
@@ -42,6 +43,7 @@ test.describe('breakage form', () => {
             screen: 'breakageForm',
             randomisedCategories: 'true',
         });
+        await dash.reducedMotion();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.categoryIsLast('Something else');
     });
@@ -52,6 +54,7 @@ test.describe('breakage form', () => {
             screen: 'breakageForm',
             randomisedCategories: 'false',
         });
+        await dash.reducedMotion();
         await dash.selectsCategoryType('I dislike the content on this site', 'dislike');
         await dash.breakageFormIsVisible('I dislike the content');
         await dash.descriptionPromptIsNotVisible();
@@ -61,6 +64,7 @@ test.describe('breakage form', () => {
     test('skips to breakage form when disliked', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.browser(page, testDataStates.google, { screen: 'breakageForm' });
+        await dash.reducedMotion();
         await dash.showsCategoryTypeSelectionForExtension();
         await dash.skipsToBreakageFormWhenDisliked();
     });
@@ -68,6 +72,7 @@ test.describe('breakage form', () => {
     test('shows empty description warning', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.browser(page, testDataStates.google, { screen: 'breakageForm' });
+        await dash.reducedMotion();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.selectsCategory('Something else', 'other');
         await dash.breakageFormIsVisible();
@@ -79,6 +84,7 @@ test.describe('breakage form', () => {
     test('submits form with description', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.browser(page, testDataStates.google, { screen: 'breakageForm' });
+        await dash.reducedMotion();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.selectsCategory('Something else', 'other');
         await dash.breakageFormIsVisible();
@@ -86,9 +92,10 @@ test.describe('breakage form', () => {
         await dash.screenshot('screen-breakage-form-success.png');
     });
 
-    test('goes back to primary screen from success screen', { tag: '@screenshots' }, async ({ page }) => {
+    test('goes back to primary screen from success screen', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.browser(page, testDataStates.google, { opener: 'dashboard' });
+        await dash.reducedMotion();
         await dash.clicksWebsiteNotWorking();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.selectsCategory('Site layout broken', 'layout');
@@ -97,9 +104,10 @@ test.describe('breakage form', () => {
         await dash.nav.goesBackToPrimaryScreenFromSuccessScreen();
     });
 
-    test('hides back button in success screen when invoked from menu', { tag: '@screenshots' }, async ({ page }) => {
+    test('hides back button in success screen when invoked from menu', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.browser(page, testDataStates.google, { opener: 'menu' });
+        await dash.reducedMotion();
         await dash.clicksWebsiteNotWorking();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.selectsCategory('Site layout broken', 'layout');
@@ -126,10 +134,12 @@ test.describe('stack based router', () => {
     test('goes back and forward in categorySelection flow', async ({ page }) => {
         const dash = await DashboardPage.browser(page, testDataStates.google);
         // await dash.reducedMotion(); // TODO: Removed because back button was going back two steps rather than one
-
         await dash.clicksWebsiteNotWorking();
+        await dash.waitForRouterToSettle();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
+        await dash.waitForRouterToSettle();
         await dash.selectsCategory('Site layout broken', 'layout');
+        await dash.waitForRouterToSettle();
         await dash.nav.goesBackToPrimaryScreenFromBreakageScreen();
     });
     test('goes back and forward generally', async ({ page }) => {
@@ -168,6 +178,7 @@ test.describe('Protections toggle -> simple report screen', () => {
     test('shows toggle report + accepts it', async ({ page }) => {
         forwardConsole(page);
         const dash = await DashboardPage.browser(page, testDataStates.protectionsOn);
+        await dash.reducedMotion();
         await dash.showsPrimaryScreen();
         await dash.toggleProtectionsOff();
         await dash.mocks.calledForToggleAllowList();
@@ -178,6 +189,7 @@ test.describe('Protections toggle -> simple report screen', () => {
     test('handles disconnect + fetches new data for toggle-report', async ({ page }) => {
         forwardConsole(page);
         const dash = await DashboardPage.browser(page, testDataStates.protectionsOn);
+        await dash.reducedMotion();
         await dash.showsPrimaryScreen();
         await dash.toggleProtectionsOff();
         await dash.mocks.calledForToggleAllowList();
@@ -190,6 +202,7 @@ test.describe('Protections toggle -> simple report screen', () => {
     test('shows toggle report + rejects it', async ({ page }) => {
         forwardConsole(page);
         const dash = await DashboardPage.browser(page, testDataStates.protectionsOn);
+        await dash.reducedMotion();
         await dash.showsPrimaryScreen();
         await dash.toggleProtectionsOff();
         await dash.mocks.calledForToggleAllowList();
@@ -300,6 +313,7 @@ test.describe('screenshots', { tag: '@screenshots' }, () => {
     for (const { name, state } of states) {
         test(name, async ({ page }) => {
             const dash = await DashboardPage.browser(page, state);
+            await dash.reducedMotion();
             await dash.screenshotEachScreenForState(name, state, { skipInCI: true });
         });
     }

--- a/integration-tests/helpers.js
+++ b/integration-tests/helpers.js
@@ -1,5 +1,11 @@
-import { mockAndroidApis, mockDataProvider, webkitMockApis, windowsMockApis } from '../shared/js/browser/utils/communication-mocks.mjs';
-import toggleReportScreen from '../schema/__fixtures__/toggle-report-screen.json';
+import {
+    mockAndroidApis,
+    sharedMockDataProvider,
+    webkitMockApis,
+    windowsMockApis,
+} from '../shared/js/browser/utils/communication-mocks.mjs';
+import { readFileSync } from 'node:fs';
+const toggleReportScreen = JSON.parse(readFileSync('./schema/__fixtures__/toggle-report-screen.json', 'utf8'));
 
 /**
  * @param {import('@playwright/test').Page} page
@@ -26,12 +32,12 @@ export async function playTimeline(page, state, platform) {
     }
     if (platform.name === 'windows') {
         messages.windowsViewModel = state.toWindowsViewModel();
-        messages.GetToggleReportOptions = state.toWindowsToggleReportOptions();
+        messages.GetToggleReportOptions = state.toWindowsToggleReportOptions(toggleReportScreen);
     }
     if (platform.name === 'ios' || platform.name === 'macos') {
         messages.privacyDashboardGetToggleReportOptions = toggleReportScreen;
     }
-    await page.evaluate(mockDataProvider, { state, platform, messages });
+    await page.evaluate(sharedMockDataProvider, { state, platform, messages });
     return messages;
 }
 

--- a/integration-tests/ios.spec-int.js
+++ b/integration-tests/ios.spec-int.js
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { testDataStates } from '../shared/js/ui/views/tests/states-with-fixtures';
+import { testDataStates } from './utils/states-with-fixtures';
 import { DashboardPage } from './DashboardPage';
 import { toggleFlows } from './utils/common-flows';
 
@@ -11,6 +11,7 @@ test.describe('page data (no trackers)', () => {
     });
     test('should accept updates when on trackers list screen', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await DashboardPage.webkit(page);
+        await dash.reducedMotion();
         await dash.addState([testDataStates.protectionsOn]);
         await dash.viewTrackerCompanies();
         await dash.screenshot('tracker-list-before.png');
@@ -20,6 +21,7 @@ test.describe('page data (no trackers)', () => {
     });
     test('should accept updates when on non-trackers list screen', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await DashboardPage.webkit(page);
+        await dash.reducedMotion();
         await dash.addState([testDataStates.protectionsOn]);
         await dash.viewThirdParties();
         await dash.screenshot('non-tracker-list-before.png');
@@ -29,6 +31,7 @@ test.describe('page data (no trackers)', () => {
     });
     test('does not alter the appearance of connection panel', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await DashboardPage.webkit(page);
+        await dash.reducedMotion();
         await dash.addState([testDataStates.protectionsOn]);
         await dash.viewConnection();
         await dash.screenshot('connection-before.png');
@@ -40,6 +43,7 @@ test.describe('page data (no trackers)', () => {
 test.describe('page data (with trackers)', () => {
     test('should display correct primary screen', { tag: '@screenshots' }, async ({ page }) => {
         const dash = await DashboardPage.webkit(page);
+        await dash.reducedMotion();
         await dash.addState([testDataStates.cnn]);
         await dash.showsPrimaryScreen();
         await dash.screenshot('primary-screen.png');
@@ -87,6 +91,7 @@ test.describe('cookie prompt management', () => {
     test.describe('none-configurable', () => {
         test('primary screen', async ({ page }) => {
             const dash = await DashboardPage.webkit(page);
+            await dash.reducedMotion();
             await dash.addState([testDataStates['consent-managed']]);
             await dash.indicatesCookiesWereManaged();
         });
@@ -95,11 +100,13 @@ test.describe('cookie prompt management', () => {
         test.describe('non-cosmetic', () => {
             test('primary screen', async ({ page }) => {
                 const dash = await DashboardPage.webkit(page);
+                await dash.reducedMotion();
                 await dash.addState([testDataStates['consent-managed-configurable']]);
                 await dash.indicatesCookiesWereManaged();
             });
             test('secondary screen', async ({ page }) => {
                 const dash = await DashboardPage.webkit(page);
+                await dash.reducedMotion();
                 await dash.addState([testDataStates['consent-managed-configurable']]);
                 await dash.viewCookiePromptManagement();
                 await dash.disableCookiesInSettings();
@@ -112,11 +119,13 @@ test.describe('cookie prompt management', () => {
         test.describe('cosmetic', () => {
             test('primary screen', async ({ page }) => {
                 const dash = await DashboardPage.webkit(page);
+                await dash.reducedMotion();
                 await dash.addState([testDataStates['consent-managed-configurable-cosmetic']]);
                 await dash.indicatesCookiesWereHidden();
             });
             test('secondary screen', async ({ page }) => {
                 const dash = await DashboardPage.webkit(page);
+                await dash.reducedMotion();
                 await dash.addState([testDataStates['consent-managed-configurable-cosmetic']]);
                 await dash.viewCookiePromptManagement();
                 await dash.disableCookiesInSettings();
@@ -132,6 +141,7 @@ test.describe('breakage form', () => {
     test('sends message when breakage form is triggered from primary screen', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { platform: 'ios', opener: 'dashboard' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.clicksWebsiteNotWorking();
         await dash.mocks.calledForReportBreakageFormShown();
@@ -140,6 +150,7 @@ test.describe('breakage form', () => {
     test('sends message when breakage form is triggered from app menu', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'ios' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.mocks.calledForReportBreakageFormShown();
     });
@@ -147,6 +158,7 @@ test.describe('breakage form', () => {
     test('shows breakage form on category selection screen only', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'ios' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.showsCategoryTypeSelection();
         await dash.showsBreakageFormTitle();
@@ -156,6 +168,7 @@ test.describe('breakage form', () => {
     test('shows native feedback screen', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'ios' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.showsCategoryTypeSelection();
         await dash.showsNativeFeedback();
@@ -188,6 +201,7 @@ test.describe('breakage form', () => {
             randomisedCategories: 'true',
             platform: 'ios',
         });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.categoryIsLast('Something else');
@@ -200,6 +214,7 @@ test.describe('breakage form', () => {
             randomisedCategories: 'false',
             platform: 'ios',
         });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.selectsCategoryType('I dislike the content on this site', 'dislike');
         await dash.breakageFormIsVisible('I dislike the content');
@@ -210,6 +225,7 @@ test.describe('breakage form', () => {
     test('skips to breakage form when disliked', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'ios' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.showsCategoryTypeSelection();
         await dash.skipsToBreakageFormWhenDisliked();
@@ -218,6 +234,7 @@ test.describe('breakage form', () => {
     test('shows empty description warning', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'ios' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.selectsCategory('Something else', 'other');
@@ -227,9 +244,10 @@ test.describe('breakage form', () => {
         await dash.screenshot('screen-breakage-form-empty-description.png');
     });
 
-    test('submits form with description', { tag: '@screenshots' }, async ({ page }) => {
+    test('submits form with description', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'ios' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.selectsCategory('Something else', 'other');
@@ -257,6 +275,7 @@ test.describe('opens toggle report', () => {
     test('sends toggle report', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'toggleReport', platform: 'ios', opener: 'menu' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.toggleReportIsVisible();
         await dash.screenshot('screen-toggle-report.png');
@@ -266,6 +285,7 @@ test.describe('opens toggle report', () => {
     test('rejects toggle report', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'toggleReport', platform: 'ios', opener: 'dashboard' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.toggleReportIsVisible();
         await dash.rejectToggleReport();
@@ -288,8 +308,11 @@ test.describe('stack based router', () => {
         await dash.addState([testDataStates.google]);
 
         await dash.clicksWebsiteNotWorking();
+        await dash.waitForRouterToSettle();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
+        await dash.waitForRouterToSettle();
         await dash.selectsCategory('Site layout broken', 'layout');
+        await dash.waitForRouterToSettle();
         await dash.nav.goesBackToPrimaryScreenFromBreakageScreen();
     });
     test('goes back and forward generally', async ({ page }) => {
@@ -301,12 +324,10 @@ test.describe('stack based router', () => {
 
         // needed to allow the router to settle
         // playwright is too fast here and is doing something a user never could
-        await page.waitForTimeout(100);
         await page.goBack();
         await dash.showsPrimaryScreen();
 
         // same as previous wait point
-        await page.waitForTimeout(100);
         await page.goForward();
         await dash.showsCategoryTypeSelection();
     });
@@ -316,6 +337,7 @@ test.describe('phishing & malware protection', () => {
     test('phishing warning', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { platform: 'ios' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.phishing]);
         await dash.screenshot('phishing-warning.png');
         await dash.hasPhishingIcon();
@@ -328,6 +350,7 @@ test.describe('phishing & malware protection', () => {
     test('malware warning', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { platform: 'ios' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.malware]);
         await dash.page.pause();
         await dash.screenshot('malware-warning.png');
@@ -341,6 +364,7 @@ test.describe('phishing & malware protection', () => {
     test('shows report as safe link', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { platform: 'ios' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.malware]);
         await dash.clickReportAsSafeLink();
         await dash.mocks.calledForReportAsSafeLink('https://privacy-test-pages.site/security/badware/malware.html');
@@ -349,6 +373,7 @@ test.describe('phishing & malware protection', () => {
     test('shows malware help page link', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { platform: 'ios' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.malware]);
         await dash.clickMalwareHelpPageLink();
         await dash.mocks.calledForHelpPagesLink();
@@ -357,6 +382,7 @@ test.describe('phishing & malware protection', () => {
     test('shows phishing help page link', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { platform: 'ios' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.phishing]);
         await dash.clickPhishingHelpPageLink();
         await dash.mocks.calledForHelpPagesLink();
@@ -389,6 +415,7 @@ test.describe('screenshots', { tag: '@screenshots' }, () => {
         test(name, async ({ page }) => {
             await page.emulateMedia({ reducedMotion: 'reduce' });
             const dash = await DashboardPage.webkit(page);
+            await dash.reducedMotion();
             await dash.screenshotEachScreenForState(name, state);
         });
     }

--- a/integration-tests/macos.spec-int.js
+++ b/integration-tests/macos.spec-int.js
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { testDataStates } from '../shared/js/ui/views/tests/states-with-fixtures';
+import { testDataStates } from './utils/states-with-fixtures';
 import { DashboardPage } from './DashboardPage';
 import { settingPermissions, toggleFlows } from './utils/common-flows';
 
@@ -22,6 +22,7 @@ test.describe('permissions', () => {
 test('invalid/missing certificate', { tag: '@screenshots' }, async ({ page }) => {
     /** @type {DashboardPage} */
     const dash = await DashboardPage.webkit(page, { platform: 'macos' });
+    await dash.reducedMotion();
     await dash.addState([testDataStates['https-without-certificate']]);
     await dash.screenshot('invalid-cert.png');
     await dash.hasInvalidCertText();
@@ -187,6 +188,7 @@ test.describe('breakage form', () => {
     test('shows empty description warning', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'macos' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.selectsCategory('Something else', 'other');
@@ -199,6 +201,7 @@ test.describe('breakage form', () => {
     test('submits form with description', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { screen: 'breakageForm', platform: 'macos' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.selectsCategory('Something else', 'other');
@@ -212,6 +215,7 @@ test.describe('breakage form', () => {
     test('goes back to primary screen from success screen', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { platform: 'macos', opener: 'dashboard' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.clicksWebsiteNotWorking();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
@@ -224,6 +228,7 @@ test.describe('breakage form', () => {
     test('hides back button in success screen when invoked from menu', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.webkit(page, { platform: 'macos', opener: 'menu' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.clicksWebsiteNotWorking();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
@@ -256,8 +261,11 @@ test.describe('stack based router', () => {
         await dash.addState([testDataStates.google]);
 
         await dash.clicksWebsiteNotWorking();
+        await dash.waitForRouterToSettle();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
+        await dash.waitForRouterToSettle();
         await dash.selectsCategory('Site layout broken', 'layout');
+        await dash.waitForRouterToSettle();
         await dash.nav.goesBackToPrimaryScreenFromBreakageScreen();
     });
 
@@ -383,8 +391,8 @@ test.describe('macos screenshots', { tag: '@screenshots' }, () => {
     test.describe('states', () => {
         for (const { name, state } of states) {
             test(name, async ({ page }) => {
-                await page.emulateMedia({ reducedMotion: 'reduce' });
                 const dash = await DashboardPage.webkit(page, { platform: 'macos' });
+                await dash.reducedMotion();
                 await dash.screenshotEachScreenForState(name, state);
             });
         }
@@ -401,12 +409,14 @@ test.describe('macos screenshots', { tag: '@screenshots' }, () => {
         test.describe('non-cosmetic', () => {
             test('primary screen', async ({ page }) => {
                 const dash = await DashboardPage.webkit(page, { platform: 'macos' });
+                await dash.reducedMotion();
                 await dash.addState([testDataStates['consent-managed-configurable']]);
                 await dash.indicatesCookiesWereManaged();
                 await dash.screenshot('consent-managed-configurable.png');
             });
             test('secondary screen', async ({ page }) => {
                 const dash = await DashboardPage.webkit(page, { platform: 'macos' });
+                await dash.reducedMotion();
                 await dash.addState([testDataStates['consent-managed-configurable']]);
                 await dash.viewCookiePromptManagement();
                 await dash.screenshot('consent-managed-configurable-secondary.png');
@@ -417,12 +427,14 @@ test.describe('macos screenshots', { tag: '@screenshots' }, () => {
         test.describe('cosmetic', () => {
             test('primary screen', async ({ page }) => {
                 const dash = await DashboardPage.webkit(page, { platform: 'macos' });
+                await dash.reducedMotion();
                 await dash.addState([testDataStates['consent-managed-configurable-cosmetic']]);
                 await dash.indicatesCookiesWereHidden();
                 await dash.screenshot('consent-managed-configurable-primary-cosmetic.png');
             });
             test('secondary screen', async ({ page }) => {
                 const dash = await DashboardPage.webkit(page, { platform: 'macos' });
+                await dash.reducedMotion();
                 await dash.addState([testDataStates['consent-managed-configurable-cosmetic']]);
                 await dash.viewCookiePromptManagement();
                 await dash.screenshot('consent-managed-configurable-secondary-cosmetic.png');

--- a/integration-tests/utils/common-flows.js
+++ b/integration-tests/utils/common-flows.js
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { testDataStates } from '../../shared/js/ui/views/tests/states-with-fixtures';
+import { testDataStates } from './states-with-fixtures';
 
 /**
  * @typedef {import("../../shared/js/ui/views/tests/generate-data.mjs").MockData} MockData

--- a/integration-tests/utils/states-with-fixtures.js
+++ b/integration-tests/utils/states-with-fixtures.js
@@ -1,0 +1,7 @@
+import { createDataStates } from '../../shared/js/ui/views/tests/generate-data.mjs';
+import { readFileSync } from 'node:fs';
+
+const google = JSON.parse(readFileSync('./schema/__fixtures__/request-data-google.json', 'utf8'));
+const cnn = JSON.parse(readFileSync('./schema/__fixtures__/request-data-cnn.json', 'utf8'));
+
+export const testDataStates = createDataStates(google, cnn);

--- a/integration-tests/windows.spec-int.js
+++ b/integration-tests/windows.spec-int.js
@@ -1,5 +1,5 @@
 import { test } from '@playwright/test';
-import { testDataStates } from '../shared/js/ui/views/tests/states-with-fixtures';
+import { testDataStates } from './utils/states-with-fixtures';
 import { DashboardPage } from './DashboardPage';
 import { settingPermissions, toggleFlows } from './utils/common-flows';
 
@@ -16,6 +16,7 @@ test.describe('breakage form', () => {
     test('sends message when breakage form is triggered from primary screen', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.windows(page);
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.clicksWebsiteNotWorking();
         await dash.mocks.calledForReportBreakageFormShown();
@@ -31,6 +32,7 @@ test.describe('breakage form', () => {
     test('shows breakage form on category selection screen only', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.windows(page, { screen: 'breakageForm' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.showsCategoryTypeSelection();
         await dash.showsOnlyCloseButton();
@@ -39,6 +41,7 @@ test.describe('breakage form', () => {
     test('shows native feedback screen', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.windows(page, { screen: 'breakageForm' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.showsCategoryTypeSelection();
         await dash.showsNativeFeedback();
@@ -70,6 +73,7 @@ test.describe('breakage form', () => {
             screen: 'breakageForm',
             randomisedCategories: 'true',
         });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.categoryIsLast('Something else');
@@ -81,6 +85,7 @@ test.describe('breakage form', () => {
             screen: 'breakageForm',
             randomisedCategories: 'false',
         });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.selectsCategoryType('I dislike the content on this site', 'dislike');
         await dash.breakageFormIsVisible('I dislike the content');
@@ -99,6 +104,7 @@ test.describe('breakage form', () => {
     test('shows empty description warning', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.windows(page, { screen: 'breakageForm' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.selectsCategory('Something else', 'other');
@@ -111,6 +117,7 @@ test.describe('breakage form', () => {
     test('submits form with description', { tag: '@screenshots' }, async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.windows(page, { screen: 'breakageForm' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
         await dash.selectsCategory('Something else', 'other');
@@ -120,9 +127,10 @@ test.describe('breakage form', () => {
         await dash.clickingSuccessScreenClosesBreakageFormScreen();
     });
 
-    test('goes back to primary screen from success screen', { tag: '@screenshots' }, async ({ page }) => {
+    test('goes back to primary screen from success screen', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.windows(page, { opener: 'dashboard' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.clicksWebsiteNotWorking();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
@@ -132,9 +140,10 @@ test.describe('breakage form', () => {
         await dash.nav.goesBackToPrimaryScreenFromSuccessScreen();
     });
 
-    test('hides back button in success screen when invoked from menu', { tag: '@screenshots' }, async ({ page }) => {
+    test('hides back button in success screen when invoked from menu', async ({ page }) => {
         /** @type {DashboardPage} */
         const dash = await DashboardPage.windows(page, { opener: 'menu' });
+        await dash.reducedMotion();
         await dash.addState([testDataStates.google]);
         await dash.clicksWebsiteNotWorking();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
@@ -165,10 +174,12 @@ test.describe('stack based router', () => {
         const dash = await DashboardPage.windows(page);
         // await dash.reducedMotion(); // TODO: Removed because back button was going back two steps rather than one
         await dash.addState([testDataStates.google]);
-
         await dash.clicksWebsiteNotWorking();
+        await dash.waitForRouterToSettle();
         await dash.selectsCategoryType('The site is not working as expected', 'notWorking');
+        await dash.waitForRouterToSettle();
         await dash.selectsCategory('Site layout broken', 'layout');
+        await dash.waitForRouterToSettle();
         await dash.nav.goesBackToPrimaryScreenFromBreakageScreen();
     });
     test('goes back and forward generally', async ({ page }) => {
@@ -334,6 +345,7 @@ test.describe('windows screenshots', { tag: '@screenshots' }, () => {
             test(name, async ({ page }) => {
                 await page.emulateMedia({ reducedMotion: 'reduce' });
                 const dash = await DashboardPage.windows(page);
+                await dash.reducedMotion();
                 await dash.screenshotEachScreenForState(name, state);
             });
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1309,12 +1309,13 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.45.3",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.3.tgz",
-            "integrity": "sha512-UKF4XsBfy+u3MFWEH44hva1Q8Da28G6RFtR2+5saw+jgAFQV5yYnB1fu68Mz7fO+5GJF3wgwAIs0UelU8TxFrA==",
+            "version": "1.50.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
+            "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.45.3"
+                "playwright": "1.50.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -6187,12 +6188,13 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.45.3",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
-            "integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
+            "version": "1.50.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+            "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.45.3"
+                "playwright-core": "1.50.1"
             },
             "bin": {
                 "playwright": "cli.js"
@@ -6205,10 +6207,11 @@
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.45.3",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
-            "integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
+            "version": "1.50.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+            "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
             },
@@ -9383,12 +9386,12 @@
             }
         },
         "@playwright/test": {
-            "version": "1.45.3",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.3.tgz",
-            "integrity": "sha512-UKF4XsBfy+u3MFWEH44hva1Q8Da28G6RFtR2+5saw+jgAFQV5yYnB1fu68Mz7fO+5GJF3wgwAIs0UelU8TxFrA==",
+            "version": "1.50.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.1.tgz",
+            "integrity": "sha512-Jii3aBg+CEDpgnuDxEp/h7BimHcUTDlpEtce89xEumlJ5ef2hqepZ+PWp1DDpYC/VO9fmWVI1IlEaoI5fK9FXQ==",
             "dev": true,
             "requires": {
-                "playwright": "1.45.3"
+                "playwright": "1.50.1"
             }
         },
         "@rtsao/scc": {
@@ -12881,19 +12884,19 @@
             }
         },
         "playwright": {
-            "version": "1.45.3",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.3.tgz",
-            "integrity": "sha512-QhVaS+lpluxCaioejDZ95l4Y4jSFCsBvl2UZkpeXlzxmqS+aABr5c82YmfMHrL6x27nvrvykJAFpkzT2eWdJww==",
+            "version": "1.50.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+            "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
             "dev": true,
             "requires": {
                 "fsevents": "2.3.2",
-                "playwright-core": "1.45.3"
+                "playwright-core": "1.50.1"
             }
         },
         "playwright-core": {
-            "version": "1.45.3",
-            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.3.tgz",
-            "integrity": "sha512-+ym0jNbcjikaOwwSZycFbwkWgfruWvYlJfThKYAlImbxUgdWFO2oW70ojPm4OpE4t6TAo2FY/smM+hpVTtkhDA==",
+            "version": "1.50.1",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+            "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
             "dev": true
         },
         "portfinder": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,7 +27,7 @@ const config: PlaywrightTestConfig = {
     /* Retry on CI only */
     retries: process.env.CI ? 2 : 0,
     /* Opt out of parallel tests on CI. */
-    workers: process.env.CI ? 1 : undefined,
+    workers: process.env.CI ? 2 : undefined,
     /* Reporter to use. See https://playwright.dev/docs/test-reporters */
     reporter: 'html',
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
@@ -39,6 +39,7 @@ const config: PlaywrightTestConfig = {
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',
+        video: { mode: 'on-first-retry' },
     },
 
     /* Configure projects for major browsers */
@@ -97,7 +98,7 @@ const config: PlaywrightTestConfig = {
 
     /* Run your local dev server before starting the tests */
     webServer: {
-        command: 'npm run serve',
+        command: 'npm run build.debug && npm run serve',
         port: 3220,
         reuseExistingServer: true,
         ignoreHTTPSErrors: true,

--- a/shared/js/browser/communication.js
+++ b/shared/js/browser/communication.js
@@ -4,7 +4,7 @@ import * as iosComms from './ios-communication.js';
 import * as androidComms from './android-communication.js';
 import * as windowsComms from './windows-communication.js';
 import * as macosComms from './macos-communication.js';
-import { installDebuggerMocks } from './utils/communication-mocks.mjs';
+import { installBrowserMocks } from './utils/browser-mocks.mjs';
 
 let defaultComms;
 
@@ -33,17 +33,20 @@ if (isIOS()) {
 if (!defaultComms) throw new Error('unsupported environment');
 
 let debug = false;
+let postInstall;
 
-// in test environments, install mocks and deliver initial data
+// in preview environments, install mocks and deliver initial data
+// NOTE: we DO NOT run this when Playwright is running, since it handles its own data mocks
 // eslint-disable-next-line no-unused-labels, no-labels
 $TEST: (() => {
     if (typeof window.__ddg_integration_test === 'undefined') {
-        installDebuggerMocks(platform).catch(console.error);
+        postInstall = installBrowserMocks(platform);
         debug = true;
     }
 })();
 
 defaultComms.setup(debug);
+postInstall?.();
 
 export { platform };
 

--- a/shared/js/browser/utils/browser-mocks.mjs
+++ b/shared/js/browser/utils/browser-mocks.mjs
@@ -1,0 +1,75 @@
+import toggleReportScreen from '../../../../schema/__fixtures__/toggle-report-screen.json';
+import { createDataStates } from '../../ui/views/tests/generate-data.mjs';
+import google from '../../../../schema/__fixtures__/request-data-google.json';
+import cnn from '../../../../schema/__fixtures__/request-data-cnn.json';
+import { mockAndroidApis, mockBrowserApis, sharedMockDataProvider, webkitMockApis, windowsMockApis } from './communication-mocks.mjs';
+
+/**
+ * @param {import('../../ui/platform-features.mjs').Platform} platform
+ */
+export function installBrowserMocks(platform) {
+    console.log('installing...');
+    if (window.__playwright) {
+        console.log('installing... NOE');
+        return () => console.log('❌ mocked already there');
+    }
+    if (platform.name === 'windows') {
+        windowsMockApis();
+    } else if (platform.name === 'ios' || platform.name === 'macos') {
+        webkitMockApis({
+            messages: {
+                privacyDashboardGetToggleReportOptions: toggleReportScreen,
+            },
+        });
+    } else if (platform.name === 'android') {
+        mockAndroidApis({
+            messages: {
+                getToggleReportOptions: toggleReportScreen,
+            },
+        });
+    } else if (platform.name === 'browser') {
+        mockBrowserApis();
+    }
+
+    const testDataStates = createDataStates(/** @type {any} */ (google), /** @type {any} */ (cnn));
+    const stateFromUrl = new URLSearchParams(window.location.search).get('state');
+
+    let mock;
+    if (stateFromUrl && stateFromUrl in testDataStates) {
+        mock = testDataStates[stateFromUrl];
+    } else {
+        mock = testDataStates.protectionsOn_blocked;
+        console.warn('state not found, falling back to default. state: ', 'protectionsOn_blocked', stateFromUrl);
+    }
+
+    console.groupCollapsed(`${platform.name} open for more Dashboard States`);
+    const urls = Object.keys(testDataStates).map((key) => {
+        const clone = new URL(location.href);
+        clone.searchParams.set('state', key);
+        return clone.href;
+    });
+    for (const url of urls) {
+        console.log(url);
+    }
+    console.groupEnd();
+
+    const messages = {};
+
+    if (platform.name === 'browser') {
+        messages.getBurnOptions = mock.toBurnOptions();
+        messages.getPrivacyDashboardData = mock.toExtensionDashboardData();
+        messages.getToggleReportOptions = toggleReportScreen;
+        messages.getBreakageFormOptions = toggleReportScreen;
+    }
+    if (platform.name === 'windows') {
+        messages.windowsViewModel = mock.toWindowsViewModel();
+        messages.GetToggleReportOptions = mock.toWindowsToggleReportOptions(toggleReportScreen);
+    }
+
+    return () =>
+        sharedMockDataProvider({
+            state: mock,
+            platform,
+            messages,
+        });
+}

--- a/shared/js/ui/views/tests/generate-data.mjs
+++ b/shared/js/ui/views/tests/generate-data.mjs
@@ -1,6 +1,5 @@
 import { Protections } from '../../../browser/utils/protections.mjs';
 import { protectionsOff } from './toggle-protections.mjs';
-import toggleReportScreen from '../../../../../schema/__fixtures__/toggle-report-screen.json';
 
 /**
  * @typedef {import('../../../browser/utils/request-details.mjs').TabData} TabData
@@ -339,14 +338,15 @@ export class MockData {
     }
 
     /**
+     * @param {import('../../../../../schema/__generated__/schema.types').ToggleReportScreen} reportScreen
      * @return {import('../../../../../schema/__generated__/schema.types').WindowsIncomingToggleReportOptions}
      */
-    toWindowsToggleReportOptions() {
+    toWindowsToggleReportOptions(reportScreen) {
         return {
             context: 'PrivacyDashboard',
             featureName: 'GetToggleReportOptions',
             id: '0.1',
-            result: /** @type {import('../../../../../schema/__generated__/schema.types').ToggleReportScreen} */ (toggleReportScreen),
+            result: reportScreen,
         };
     }
 

--- a/shared/js/ui/views/tests/states-with-fixtures.js
+++ b/shared/js/ui/views/tests/states-with-fixtures.js
@@ -1,6 +1,0 @@
-import google from '../../../../../schema/__fixtures__/request-data-google.json';
-import cnn from '../../../../../schema/__fixtures__/request-data-cnn.json';
-import { createDataStates } from './generate-data.mjs';
-
-// @ts-expect-error
-export const testDataStates = createDataStates(google, cnn);


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:** @mgurgel 

https://app.asana.com/0/1200835453786799/1209359170590866

## Description:

- [x] we have allowed some `import json from "some.json` to creep into the test code - this prevents some versions of node from being able to execute the playwright test suite. In particular, it prevented my IDE from being able to run single tests in isolation. So I've made the boundary clearer by moving the browser mocks into a separate file

## Steps to test this PR:

<!-- List steps to test it manually
1. <STEP 1>
-->
