### PR TITLE
Enable max-height for trackers and non-trackers on macOS and Windows

### DIFF
--- a/v2/screens/non-trackers-screen.jsx
+++ b/v2/screens/non-trackers-screen.jsx
@@ -2,6 +2,7 @@
 import { h } from 'preact';
 import { DomNode } from '../dom-node';
 import { useData } from '../data-provider';
+import { platform } from '../../shared/js/browser/communication.js';
 import { heroFromTabNonTrackers } from '../../shared/js/ui/templates/shared/hero';
 import { platformLimitations } from '../../shared/js/ui/templates/shared/platform-limitations';
 import { sectionsFromSiteNonTracker } from '../../shared/js/ui/templates/page-non-trackers';
@@ -12,8 +13,11 @@ export function NonTrackersScreen() {
     // const c = useChannel()
     const data = useData();
     const ref = useRippleChildren(data.count);
+    const shouldCapHeight = platform.name === 'macos' || platform.name === 'windows' || platform.name === 'browser';
+    const maxViewHeight = 700;
+
     return (
-        <div className="site-info card page-inner" data-page="non-trackers">
+        <div className="site-info card page-inner" data-page="non-trackers" data-max-view-height={shouldCapHeight && maxViewHeight}>
             <SecondaryTopNav />
             <div className="padding-x-double" ref={ref}>
                 {/* @ts-ignore */}

--- a/v2/screens/trackers-screen.jsx
+++ b/v2/screens/trackers-screen.jsx
@@ -2,6 +2,7 @@
 import { h } from 'preact';
 import { DomNode } from '../dom-node';
 import { useData } from '../data-provider';
+import { platform } from '../../shared/js/browser/communication.js';
 import { heroFromTabTrackers } from '../../shared/js/ui/templates/shared/hero';
 import { sectionsFromSiteTrackers } from '../../shared/js/ui/templates/page-trackers';
 import { platformLimitations } from '../../shared/js/ui/templates/shared/platform-limitations';
@@ -11,8 +12,11 @@ import { useRippleChildren } from '../../shared/js/ui/hooks/useRipple';
 export function TrackersScreen() {
     const data = useData();
     const ref = useRippleChildren(data.count);
+    const shouldCapHeight = platform.name === 'macos' || platform.name === 'windows' || platform.name === 'browser';
+    const maxViewHeight = 700;
+
     return (
-        <div className="site-info card page-inner" data-page="trackers">
+        <div className="site-info card page-inner" data-page="trackers" data-max-view-height={shouldCapHeight && maxViewHeight}>
             <SecondaryTopNav />
             <div className="padding-x-double" ref={ref}>
                 {/* @ts-ignore */}


### PR DESCRIPTION
**Reviewer:** @shakyShane 

Asana: https://app.asana.com/0/1204912272578138/1206836677703864

## Description:

The breakage form has a height cap applied to the setSize method on macOS and Windows to prevent the popover from growing to a ridiculous height.

This change applies the same height cap to the Trackers and Non-Trackers subviews of the dashboard


## Steps to test this PR:

This needs to be tested natively. Test build to come soon...
