### PR TITLE
Node 22.14 fix

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 engine-strict=true
-node-options=--no-experimental-require-module

--- a/integration-tests/DashboardPage.js
+++ b/integration-tests/DashboardPage.js
@@ -5,7 +5,7 @@ import { Nav } from './Nav';
 import { testDataStates } from './utils/states-with-fixtures';
 import { mockBrowserApis } from '../shared/js/browser/utils/communication-mocks.mjs';
 import { Extension } from './Extension';
-import toggleReportScreen from '../schema/__fixtures__/toggle-report-screen.json';
+import toggleReportScreen from '../schema/__fixtures__/toggle-report-screen.json' assert { type: 'json' };
 
 export class DashboardPage {
     connectInfoLink = () => this.page.locator('[aria-label="View Connection Information"]');

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "build",
         "schema/__**/*"
     ],
+    "type": "module",
     "scripts": {
         "start": "npm run dev",
         "dev": "chokidar \"v2\" \"shared\" 'debugger' \"schema/*.json\" -c \"npm run build.debug\" --initial \"npm run build.debug\"",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "target": "es2021",
-        "module": "es2022",
+        "module": "ESNext",
         "moduleResolution": "node",
         "alwaysStrict": true,
         "allowJs": true,


### PR DESCRIPTION
**Reviewer:** @shakyShane 

## Description:

Node 22.14 introduces stricter ESM/require checking which results in the following error in CI:

```
Error: require() of ES Module .../privacy-dashboard/shared/js/ui/views/tests/generate-data.mjs from .../privacy-dashboard/integration-tests/utils/states-with-fixtures.js not supported.
Instead change the require of .../privacy-dashboard/shared/js/ui/views/tests/generate-data.mjs to a dynamic import() which is available in all CommonJS modules.
```

Trying to fix this at the config level without having to resort to dynamic imports. 


## Steps to test this PR:

1. Force your node version to 22.14 (do not rely on .nvmrc)
2. Run `npm run test.int` and watch for errors
