### PR TITLE
Updated Scam Blocker help page URLs

### DIFF
--- a/integration-tests/Mocks.js
+++ b/integration-tests/Mocks.js
@@ -399,7 +399,7 @@ export class Mocks {
     }
 
     async calledForHelpPagesLink() {
-        return this.calledForOpenURLInNewTab('https://duckduckgo.com/duckduckgo-help-pages/privacy/phishing-and-malware-protection/');
+        return this.calledForOpenURLInNewTab('https://duckduckgo.com/duckduckgo-help-pages/privacy/scam-blocker');
     }
 
     async calledForReportAsSafeLink(urlParam) {

--- a/shared/data/constants.js
+++ b/shared/data/constants.js
@@ -16,6 +16,6 @@ export const httpsMessages = {
 };
 
 export const duckDuckGoURLs = {
-    phishingAndMalwareHelpPage: 'https://duckduckgo.com/duckduckgo-help-pages/privacy/phishing-and-malware-protection/',
+    phishingAndMalwareHelpPage: 'https://duckduckgo.com/duckduckgo-help-pages/privacy/scam-blocker',
     reportSiteAsSafeForm: 'https://duckduckgo.com/malicious-site-protection/report-error',
 };


### PR DESCRIPTION
**Reviewer:**
Asana: https://app.asana.com/1/137249556945/project/1163321984198618/task/1210184950929162?focus=true

## Description:

The Phishing and Malware protection help page will be moved as part of the Scam Blocker rollout. This work updates that URL in Privacy Dashboard

## Steps to test this PR:

1. `npm run build && npm run preview`
2. Visit a malware/phishing/scam preview such as http://127.0.0.1:3220/html/iframe.html?state=malware
3. Confirm that the "About our Malware protection" link points to https://duckduckgo.com/duckduckgo-help-pages/privacy/scam-blocker (That URL is not yet available -- opening it now will take you to the DDG home)