### PR TITLE
Experiment groups translations and locale key update

### DIFF
--- a/shared/data/text.js
+++ b/shared/data/text.js
@@ -22,7 +22,7 @@ export function namedString(item) {
         case 'appVersion':
             return ns.toggleReport('dynamic_appVersion.title');
         case 'atb':
-            return ns.toggleReport('dynamic_atb.title');
+            return ns.toggleReport('dynamic_experimentGroups.title');
         case 'errorDescriptions':
             return ns.toggleReport('dynamic_errorDescriptions.title');
         case 'extensionVersion':

--- a/shared/locales/bg/toggle-report.json
+++ b/shared/locales/bg/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Номер на версията на приложението",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Анонимни експериментни групи за тестване на функции",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/bg/toggle-report.json
+++ b/shared/locales/bg/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Анонимна експериментална група за тестване на функции",
+    "title" : "Анонимни експериментни групи за тестване на функции",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/cs/toggle-report.json
+++ b/shared/locales/cs/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Číslo verze aplikace",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonymní experimentální skupiny pro testování funkcí",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/cs/toggle-report.json
+++ b/shared/locales/cs/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonymní experimentální skupina pro testování funkcí",
+    "title" : "Anonymní experimentální skupiny pro testování funkcí",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/da/toggle-report.json
+++ b/shared/locales/da/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Appens versionsnummer",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonyme eksperimentgrupper til test af funktioner",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/da/toggle-report.json
+++ b/shared/locales/da/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonym eksperimentgruppe til test af funktioner",
+    "title" : "Anonyme eksperimentgrupper til test af funktioner",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/de/toggle-report.json
+++ b/shared/locales/de/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonyme Experimentiergruppe für Funktionstests",
+    "title" : "Anonyme Experimentiergruppen für Funktionstests",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/de/toggle-report.json
+++ b/shared/locales/de/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "App-Versionsnummer",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonyme Experimentiergruppen für Funktionstests",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/el/toggle-report.json
+++ b/shared/locales/el/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Αριθμός έκδοσης εφαρμογής",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Ανώνυμες πειραματικές ομάδες για δοκιμή λειτουργιών",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/el/toggle-report.json
+++ b/shared/locales/el/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Ανώνυμη πειραματική ομάδα για δοκιμή λειτουργιών",
+    "title" : "Ανώνυμες πειραματικές ομάδες για δοκιμή λειτουργιών",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/en/toggle-report.json
+++ b/shared/locales/en/toggle-report.json
@@ -51,7 +51,7 @@
     "title": "App version number",
     "note": "This text indicates the version number of the app."
   },
-  "dynamic_atb": {
+  "dynamic_experimentGroups": {
     "title": "Anonymous experiment groups for feature testing",
     "note": "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/es/toggle-report.json
+++ b/shared/locales/es/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Grupo de experimentos anónimo para pruebas de funciones",
+    "title" : "Grupos de experimentos anónimos para pruebas de funciones",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/es/toggle-report.json
+++ b/shared/locales/es/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Número de versión de la aplicación",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Grupos de experimentos anónimos para pruebas de funciones",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/et/toggle-report.json
+++ b/shared/locales/et/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonüümne katserühm funktsioonide testimiseks",
+    "title" : "Anonüümsed katserühmad funktsioonide testimiseks",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/et/toggle-report.json
+++ b/shared/locales/et/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Rakenduse versiooni number",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonüümsed katserühmad funktsioonide testimiseks",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/fi/toggle-report.json
+++ b/shared/locales/fi/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonyymi kokeiluryhmä ominaisuuden testaamiseksi",
+    "title" : "Anonyymit kokeiluryhmät ominaisuuden testaamiseksi",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/fi/toggle-report.json
+++ b/shared/locales/fi/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Sovelluksen versionumero",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonyymit kokeiluryhmät ominaisuuden testaamiseksi",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/fr/toggle-report.json
+++ b/shared/locales/fr/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Numéro de version de l'application",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Groupes d'expérimentation anonymes pour les tests de fonctionnalités",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/fr/toggle-report.json
+++ b/shared/locales/fr/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Groupe d'expérimentation anonyme pour les tests de fonctionnalités",
+    "title" : "Groupes d'expérimentation anonymes pour les tests de fonctionnalités",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/hr/toggle-report.json
+++ b/shared/locales/hr/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonimna eksperimentalna skupina za testiranje značajki",
+    "title" : "Anonimne eksperimentalne skupine za testiranje značajki",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/hr/toggle-report.json
+++ b/shared/locales/hr/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Broj verzije aplikacije",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonimne eksperimentalne skupine za testiranje značajki",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/hu/toggle-report.json
+++ b/shared/locales/hu/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Funkciókat tesztelő névtelen kísérleti csoport",
+    "title" : "Funkciókat tesztelő névtelen kísérleti csoportok",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/hu/toggle-report.json
+++ b/shared/locales/hu/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Alkalmazás verziószáma",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Funkciókat tesztelő névtelen kísérleti csoportok",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/it/toggle-report.json
+++ b/shared/locales/it/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Numero di versione dell'app",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Gruppi di sperimentazione anonimi per testare le funzionalità",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/it/toggle-report.json
+++ b/shared/locales/it/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Gruppo di esperimenti anonimo per il test delle funzionalità",
+    "title" : "Gruppi di sperimentazione anonimi per testare le funzionalità",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/lt/toggle-report.json
+++ b/shared/locales/lt/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Programėlės versijos numeris",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anoniminės eksperimentinės grupės funkcijų testavimui",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/lt/toggle-report.json
+++ b/shared/locales/lt/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anoniminė eksperimentinė grupė funkcijų testavimui",
+    "title" : "Anoniminės eksperimentinės grupės funkcijų testavimui",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/lv/toggle-report.json
+++ b/shared/locales/lv/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Lietotnes versijas numurs",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonīmas eksperimentālās grupas funkciju testēšanai",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/lv/toggle-report.json
+++ b/shared/locales/lv/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonīma eksperimentālā grupa funkciju testēšanai",
+    "title" : "Anonīmas eksperimentālās grupas funkciju testēšanai",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/nb/toggle-report.json
+++ b/shared/locales/nb/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonym eksperimentgruppe for funksjonstesting",
+    "title" : "Anonyme eksperimentgrupper for funksjonstesting",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/nb/toggle-report.json
+++ b/shared/locales/nb/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Appversjonsnummer",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonyme eksperimentgrupper for funksjonstesting",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/nl/toggle-report.json
+++ b/shared/locales/nl/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonieme experimenteergroep voor het testen van functies",
+    "title" : "Anonieme experimenteergroepen voor het testen van functies",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/nl/toggle-report.json
+++ b/shared/locales/nl/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Versienummer van de app",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonieme experimenteergroepen voor het testen van functies",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/pl/toggle-report.json
+++ b/shared/locales/pl/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Numer wersji aplikacji",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonimowe grupy eksperymentalne do testowania funkcji",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/pl/toggle-report.json
+++ b/shared/locales/pl/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonimowa grupa eksperymentalna do testowania funkcji",
+    "title" : "Anonimowe grupy eksperymentalne do testowania funkcji",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/pt/toggle-report.json
+++ b/shared/locales/pt/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Número da versão da aplicação",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Grupos experimentais anónimos para testes de funcionalidades",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/pt/toggle-report.json
+++ b/shared/locales/pt/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Grupo experimental anónimo para testes de funcionalidades",
+    "title" : "Grupos experimentais anónimos para testes de funcionalidades",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/ro/toggle-report.json
+++ b/shared/locales/ro/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Numărul versiunii aplicației",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Grupuri de încercare anonime pentru testarea caracteristicilor",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/ro/toggle-report.json
+++ b/shared/locales/ro/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Grup de experimentare anonim pentru testarea caracteristicilor",
+    "title" : "Grupuri de încercare anonime pentru testarea caracteristicilor",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/ru/toggle-report.json
+++ b/shared/locales/ru/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "анонимная экспериментальная группа для тестирования функций",
+    "title" : "Анонимные экспериментальные группы для тестирования функций",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/ru/toggle-report.json
+++ b/shared/locales/ru/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "номер версии приложения",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Анонимные экспериментальные группы для тестирования функций",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/sk/toggle-report.json
+++ b/shared/locales/sk/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonymná experimentálna skupina na testovanie funkcií",
+    "title" : "Anonymné experimentálne skupiny na testovanie funkcií",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/sk/toggle-report.json
+++ b/shared/locales/sk/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Číslo verzie aplikácie",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonymné experimentálne skupiny na testovanie funkcií",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/sl/toggle-report.json
+++ b/shared/locales/sl/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonimna eksperimentalna skupina za testiranje funkcij",
+    "title" : "Anonimne eksperimentalne skupine za testiranje funkcij",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/sl/toggle-report.json
+++ b/shared/locales/sl/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Številka različice aplikacije",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonimne eksperimentalne skupine za testiranje funkcij",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/sv/toggle-report.json
+++ b/shared/locales/sv/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Appversionsnummer",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Anonyma experimentgrupper för funktionstestning",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/sv/toggle-report.json
+++ b/shared/locales/sv/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Anonym experimentgrupp för funktionstestning",
+    "title" : "Anonyma experimentgrupper för funktionstestning",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {

--- a/shared/locales/tr/toggle-report.json
+++ b/shared/locales/tr/toggle-report.json
@@ -52,7 +52,7 @@
     "title" : "Uygulama sürüm numarası",
     "note" : "This text indicates the version number of the app."
   },
-  "dynamic_atb" : {
+  "dynamic_experimentGroups" : {
     "title" : "Özellik testi için anonim deneme grupları",
     "note" : "This text represents an anonymous group for testing features."
   },

--- a/shared/locales/tr/toggle-report.json
+++ b/shared/locales/tr/toggle-report.json
@@ -53,7 +53,7 @@
     "note" : "This text indicates the version number of the app."
   },
   "dynamic_atb" : {
-    "title" : "Özellik testi için anonim deneme grubu",
+    "title" : "Özellik testi için anonim deneme grupları",
     "note" : "This text represents an anonymous group for testing features."
   },
   "dynamic_errorDescriptions" : {


### PR DESCRIPTION
**Reviewer:** @shakyShane 
Asana task: https://app.asana.com/1/137249556945/task/1210237517707665?focus=true

## Description:

This is a follow up to https://github.com/duckduckgo/privacy-dashboard/pull/424 

- Added translations for the string "Anonymous experiment groups for feature testing"
- Renamed the locale key `dynamic_atb` to `dynamic_experimentGroups` to better reflect the copy change

Out of scope for this PR: renaming the `atb` id that gets passed from native platforms to the dashboard. 

## Steps to test this PR:

1. Visit the [Breakage Form preview in French](https://deploy-preview-435--ddgdash.netlify.app/app-debug/html/iframe?locale=es&state=locale-fr&screen=breakageFormFinalStep) 
1b. Alternatively, run the preview locally and pass any locale into the mock data. Example: `{ localeSettings: { locale: 'es' } }`
2. Expand the "See what's sent" control ("Voir ce qui...") 
3. Check that the translated text for "Anonymous experiment groups for feature testing" has groups in plural. In French, it should read "Groupes d'expérimentation anonymes..."
<img width="301" alt="image" src="https://github.com/user-attachments/assets/52b95092-47de-40fd-b591-f3d78a96ff23" />


