### PR TITLE
Update @duckduckgo/design-tokens to v0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
             "name": "@duckduckgo/privacy-dashboard",
             "version": "7.3.2",
             "devDependencies": {
-                "@duckduckgo/design-tokens": "github:duckduckgo/design-tokens#v0.2.0",
+                "@duckduckgo/design-tokens": "github:duckduckgo/design-tokens#v0.3.0",
                 "@duckduckgo/eslint-config": "github:duckduckgo/eslint-config#v0.1.0",
                 "@formatjs/intl-locale": "^3.0.7",
                 "@material/ripple": "^14.0.0",
@@ -72,8 +72,8 @@
         },
         "node_modules/@duckduckgo/design-tokens": {
             "name": "design-tokens",
-            "version": "0.2.0",
-            "resolved": "git+ssh://git@github.com/duckduckgo/design-tokens.git#5876916740931b3082582c9d338a8193e25f68da",
+            "version": "0.3.0",
+            "resolved": "git+ssh://git@github.com/duckduckgo/design-tokens.git#90348b07e8d579ab5b88bec4d3773541bd05c3bf",
             "dev": true,
             "license": "ISC"
         },
@@ -7448,9 +7448,9 @@
             }
         },
         "@duckduckgo/design-tokens": {
-            "version": "git+ssh://git@github.com/duckduckgo/design-tokens.git#5876916740931b3082582c9d338a8193e25f68da",
+            "version": "git+ssh://git@github.com/duckduckgo/design-tokens.git#90348b07e8d579ab5b88bec4d3773541bd05c3bf",
             "dev": true,
-            "from": "@duckduckgo/design-tokens@github:duckduckgo/design-tokens#v0.2.0"
+            "from": "@duckduckgo/design-tokens@github:duckduckgo/design-tokens#v0.3.0"
         },
         "@duckduckgo/eslint-config": {
             "version": "git+ssh://git@github.com/duckduckgo/eslint-config.git#09f3780bb1826fe123ef3e4eb36dcbd53ca1fd80",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
         "postfetch-fonts": "cp -R build/app/public/font build/app-debug/public/font"
     },
     "devDependencies": {
-        "@duckduckgo/design-tokens": "github:duckduckgo/design-tokens#v0.2.0",
+        "@duckduckgo/design-tokens": "github:duckduckgo/design-tokens#v0.3.0",
         "@duckduckgo/eslint-config": "github:duckduckgo/eslint-config#v0.1.0",
         "@formatjs/intl-locale": "^3.0.7",
         "@material/ripple": "^14.0.0",


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:**
-->

## Description:

Updates @duckduckgo/design-tokens to v0.3.0 so that we’re using the updated values in https://app.asana.com/1/137249556945/task/1211371913634199?focus=true. See https://github.com/duckduckgo/design-tokens/pull/2.

## Steps to test this PR:

Smoke test https://deploy-preview-602--ddgdash.netlify.app/app-debug/html/macos.html?themeVariant=green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates dependency versions only.
> 
> - Bumps `@duckduckgo/design-tokens` from `v0.2.0` to `v0.3.0` in `package.json`
> - Regenerates `package-lock.json` to resolve to the new commit (`90348b0...`) for `design-tokens`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42d0f7125bfb0666e71ce28dc9ee4cdb6d6dad49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->