### PR TITLE
Use Surface Secondary as background color

### DIFF
--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -121,8 +121,8 @@ body {
     // macOS and Windows use design system colors
     &.environment--macos,
     &.environment--windows {
-        --bg: var(--ds-color-theme-surface-canvas);
-        --page-bg: var(--ds-color-theme-surface-canvas);
+        --bg: var(--ds-color-theme-surface-secondary);
+        --page-bg: var(--ds-color-theme-surface-secondary);
         --color-text-primary: var(--ds-color-theme-text-primary);
         --color-text-secondary: var(--ds-color-theme-text-secondary);
         --color-button-primary: var(--ds-color-theme-accent-content-primary);


### PR DESCRIPTION
<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**
**Asana Task:** https://app.asana.com/1/137249556945/project/1209121419454298/task/1213279365107559?focus=true

## Description:

Changes the Privacy Dashboard background color from Surface Canvas to Surface Secondary on macOS and Windows.

## Steps to test this PR:

1. Smoke test the deploy preview on macOS and Windows, in both light and dark mode, across theme variants.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, platform-scoped CSS token swap; risk is limited to visual regressions in macOS/Windows light/dark and theme variants.
> 
> **Overview**
> Updates the popup (Privacy Dashboard) styling on macOS and Windows to use design-system `surface-secondary` for both `--bg` and `--page-bg` instead of `surface-canvas`, changing the base background color across themes/modes on those platforms.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3206ea1ca7c0d2817bd704b8e46f4639397283c4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->