### PR TITLE
Add cookie clearing warning and Learn more link to fire dialog for site-specific data clearing

### DIFF
--- a/integration-tests/DashboardPage.js
+++ b/integration-tests/DashboardPage.js
@@ -6,6 +6,7 @@ import { testDataStates } from './utils/states-with-fixtures';
 import { mockBrowserApis } from '../shared/js/browser/utils/communication-mocks.mjs';
 import { Extension } from './Extension';
 import toggleReportScreen from '../schema/__fixtures__/toggle-report-screen.json' assert { type: 'json' };
+import { duckDuckGoURLs } from '../shared/data/constants.js';
 
 export class DashboardPage {
     connectInfoLink = () => this.page.locator('[aria-label="View Connection Information"]');
@@ -883,9 +884,8 @@ export class DashboardPage {
         await expect(this.page.locator('#fire-button-summary')).toContainText('This will reset your Search settings.');
         const learnMore = this.page.locator('#fire-button-summary a.fire-button-learn-more');
         await expect(learnMore).toHaveText('Learn More');
-        await expect(learnMore).toHaveAttribute('href', 'https://duckduckgo.com/duckduckgo-help-pages/settings/save');
+        await expect(learnMore).toHaveAttribute('href', duckDuckGoURLs.settingsHelpPage);
     }
-
 
     async clicksWebsiteNotWorking() {
         await this.page.getByRole('link', { name: 'Report a problem with this site' }).click({ timeout: 5000 });

--- a/integration-tests/DashboardPage.js
+++ b/integration-tests/DashboardPage.js
@@ -844,7 +844,7 @@ export class DashboardPage {
     }
 
     async fireDialogIsPopulatedFromOptions(getBurnOptions) {
-        await expect(this.page.locator('#fire-button-burn')).toHaveText('Clear');
+        await expect(this.page.locator('#fire-button-burn')).toHaveText('Delete');
         // check that dropdown options are populated
         await expect(this.page.locator('#fire-button-opts > option')).toHaveCount(getBurnOptions.options.length);
         // there should be two text sections: summary and a notice
@@ -855,7 +855,7 @@ export class DashboardPage {
     }
 
     async fireDialogHistoryDisabled() {
-        await expect(this.page.locator('#fire-button-burn')).toHaveText('Clear');
+        await expect(this.page.locator('#fire-button-burn')).toHaveText('Delete');
     }
 
     async clickFireButtonBurn() {
@@ -880,9 +880,9 @@ export class DashboardPage {
     }
 
     async fireDialogShowsCookieWarning() {
-        await expect(this.page.locator('#fire-button-summary')).toContainText('Clearing cookies will reset your Search preferences.');
+        await expect(this.page.locator('#fire-button-summary')).toContainText('This will reset your Search settings.');
         const learnMore = this.page.locator('#fire-button-summary a.fire-button-learn-more');
-        await expect(learnMore).toHaveText('Learn more');
+        await expect(learnMore).toHaveText('Learn More');
         await expect(learnMore).toHaveAttribute('href', 'https://duckduckgo.com/duckduckgo-help-pages/settings/save');
     }
 

--- a/integration-tests/DashboardPage.js
+++ b/integration-tests/DashboardPage.js
@@ -879,6 +879,14 @@ export class DashboardPage {
         await this.page.locator('#fire-button-opts').selectOption({ index });
     }
 
+    async fireDialogShowsCookieWarning() {
+        await expect(this.page.locator('#fire-button-summary')).toContainText('Clearing cookies will reset your Search preferences.');
+        const learnMore = this.page.locator('#fire-button-summary a.fire-button-learn-more');
+        await expect(learnMore).toHaveText('Learn more');
+        await expect(learnMore).toHaveAttribute('href', 'https://duckduckgo.com/duckduckgo-help-pages/settings/save');
+    }
+
+
     async clicksWebsiteNotWorking() {
         await this.page.getByRole('link', { name: 'Report a problem with this site' }).click({ timeout: 5000 });
     }

--- a/integration-tests/browser.spec-int.js
+++ b/integration-tests/browser.spec-int.js
@@ -296,6 +296,11 @@ test.describe('fire button', () => {
         await dash.clickFireButtonBurn();
         await dash.sendsOptionsWithBurnMessage(messages.getBurnOptions.options[1].options);
     });
+    test('fire button menu: shows cookie warning and learn more link for site-specific clearing', async ({ page }) => {
+        const dash = await DashboardPage.browser(page, testDataStates['fire-button-no-pinned']);
+        await dash.clickFireButton();
+        await dash.fireDialogShowsCookieWarning();
+    });
 });
 
 test.describe('screenshots', { tag: '@screenshots' }, () => {

--- a/integration-tests/browser.spec-int.js
+++ b/integration-tests/browser.spec-int.js
@@ -296,8 +296,8 @@ test.describe('fire button', () => {
         await dash.clickFireButtonBurn();
         await dash.sendsOptionsWithBurnMessage(messages.getBurnOptions.options[1].options);
     });
-    test('fire button menu: shows cookie warning and learn more link for site-specific clearing', async ({ page }) => {
-        const dash = await DashboardPage.browser(page, testDataStates['fire-button-no-pinned']);
+    test('fire button menu: shows cookie warning and learn more link for duckduckgo.com', async ({ page }) => {
+        const dash = await DashboardPage.browser(page, testDataStates['fire-button-ddg-site']);
         await dash.clickFireButton();
         await dash.fireDialogShowsCookieWarning();
     });

--- a/shared/data/constants.js
+++ b/shared/data/constants.js
@@ -18,4 +18,5 @@ export const httpsMessages = {
 export const duckDuckGoURLs = {
     phishingAndMalwareHelpPage: 'https://duckduckgo.com/duckduckgo-help-pages/threat-protection/scam-blocker',
     reportSiteAsSafeForm: 'https://duckduckgo.com/malicious-site-protection/report-error',
+    settingsHelpPage: 'https://duckduckgo.com/duckduckgo-help-pages/settings/save',
 };

--- a/shared/js/ui/views/fire-dialog.js
+++ b/shared/js/ui/views/fire-dialog.js
@@ -35,7 +35,7 @@ export function fireSummaryTemplate(selectedOption) {
                     ...descriptionStats,
                 })
             )}
-            ${descriptionStats.site
+            ${descriptionStats.site === 'duckduckgo.com'
                 ? html` ${i18n.t('firebutton:clearingCookiesWarning.title')}
                       <a class="fire-button-learn-more" href="https://duckduckgo.com/duckduckgo-help-pages/settings/save" target="_blank"
                           >${i18n.t('firebutton:learnMore.title')}</a

--- a/shared/js/ui/views/fire-dialog.js
+++ b/shared/js/ui/views/fire-dialog.js
@@ -1,6 +1,7 @@
 import html from 'nanohtml';
 import raw from 'nanohtml/raw';
 import { i18n } from '../base/localize.js';
+import { duckDuckGoURLs } from '../../../data/constants.js';
 
 /**
  * Generate a string to describe what will be burned.
@@ -37,7 +38,7 @@ export function fireSummaryTemplate(selectedOption) {
             )}
             ${descriptionStats.site === 'duckduckgo.com'
                 ? html` ${i18n.t('firebutton:clearingCookiesWarning.title')}
-                      <a class="fire-button-learn-more" href="https://duckduckgo.com/duckduckgo-help-pages/settings/save" target="_blank"
+                      <a class="fire-button-learn-more" href="${duckDuckGoURLs.settingsHelpPage}" target="_blank"
                           >${i18n.t('firebutton:learnMore.title')}</a
                       >`
                 : null}

--- a/shared/js/ui/views/fire-dialog.js
+++ b/shared/js/ui/views/fire-dialog.js
@@ -35,6 +35,12 @@ export function fireSummaryTemplate(selectedOption) {
                     ...descriptionStats,
                 })
             )}
+            ${descriptionStats.site
+                ? html` ${i18n.t('firebutton:clearingCookiesWarning.title')}
+                      <a class="fire-button-learn-more" href="https://duckduckgo.com/duckduckgo-help-pages/settings/save" target="_blank"
+                          >${i18n.t('firebutton:learnMore.title')}</a
+                      >`
+                : null}
         </p>
         ${descriptionStats.site && descriptionStats.clearHistory
             ? html`<p class="fire-button-disclaimer">${i18n.t('firebutton:historyAndDownloadsNotAffected.title')}</p>`

--- a/shared/js/ui/views/tests/generate-data.mjs
+++ b/shared/js/ui/views/tests/generate-data.mjs
@@ -228,7 +228,7 @@ export const permissions = [
 ];
 
 /**
- * @typedef {{ clearHistory: boolean, tabClearEnabled: boolean, pinnedTabs: number }} BurnConfig
+ * @typedef {{ clearHistory: boolean, tabClearEnabled: boolean, pinnedTabs: number, defaultOption?: string }} BurnConfig
  */
 
 /**

--- a/shared/js/ui/views/tests/generate-data.mjs
+++ b/shared/js/ui/views/tests/generate-data.mjs
@@ -814,6 +814,16 @@ export const createDataStates = (google, cnn) => {
             fireButtonEnabled: true,
             fireButtonOptions: { clearHistory: true, tabClearEnabled: true, pinnedTabs: 0, defaultOption: 'LastHour' },
         }),
+        'fire-button-google-site': new MockData({
+            url: 'https://google.com',
+            fireButtonEnabled: true,
+            fireButtonOptions: { clearHistory: true, tabClearEnabled: true, pinnedTabs: 0, defaultOption: 'CurrentSite' },
+        }),
+        'fire-button-google-time-based': new MockData({
+            url: 'https://google.com',
+            fireButtonEnabled: true,
+            fireButtonOptions: { clearHistory: true, tabClearEnabled: true, pinnedTabs: 0, defaultOption: 'LastHour' },
+        }),
         'fire-button-tab-clear-disabled': new MockData({
             url: 'https://example.com',
             fireButtonEnabled: true,

--- a/shared/js/ui/views/tests/generate-data.mjs
+++ b/shared/js/ui/views/tests/generate-data.mjs
@@ -398,17 +398,19 @@ export class MockData {
      */
     toBurnOptions() {
         const burnConfig = this.fireButtonOptions || { clearHistory: true, tabClearEnabled: true, pinnedTabs: 2 };
-        const { clearHistory, pinnedTabs, tabClearEnabled } = burnConfig;
+        const { clearHistory, pinnedTabs, tabClearEnabled, defaultOption } = burnConfig;
+        const siteHostname = new URL(this.url).hostname.replace(/^www\./, '');
         return {
             options: [
                 {
                     name: 'CurrentSite',
+                    selected: defaultOption === 'CurrentSite',
                     options: {
-                        origins: ['https://example.com/'],
+                        origins: [this.url + '/'],
                     },
                     descriptionStats: {
                         clearHistory,
-                        site: 'example.com',
+                        site: siteHostname,
                         duration: 'all',
                         openTabs: tabClearEnabled ? 1 : 0,
                         cookies: 1,
@@ -417,6 +419,7 @@ export class MockData {
                 },
                 {
                     name: 'LastHour',
+                    selected: defaultOption === 'LastHour',
                     options: {
                         since: Date.now(),
                     },
@@ -800,6 +803,16 @@ export const createDataStates = (google, cnn) => {
             url: 'https://example.com',
             fireButtonEnabled: true,
             fireButtonOptions: { clearHistory: true, tabClearEnabled: true, pinnedTabs: 0 },
+        }),
+        'fire-button-ddg-site': new MockData({
+            url: 'https://duckduckgo.com',
+            fireButtonEnabled: true,
+            fireButtonOptions: { clearHistory: true, tabClearEnabled: true, pinnedTabs: 0, defaultOption: 'CurrentSite' },
+        }),
+        'fire-button-ddg-time-based': new MockData({
+            url: 'https://duckduckgo.com',
+            fireButtonEnabled: true,
+            fireButtonOptions: { clearHistory: true, tabClearEnabled: true, pinnedTabs: 0, defaultOption: 'LastHour' },
         }),
         'fire-button-tab-clear-disabled': new MockData({
             url: 'https://example.com',

--- a/shared/locales/bg/firebutton.json
+++ b/shared/locales/bg/firebutton.json
@@ -10,103 +10,111 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Затваряне на разделите и изчистване на данните",
+    "title": "Затваряне на разделите и изтриване на данните",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Изчистване на данни",
+    "title": "Изтриване на данни",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Само за текущия сайт",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Последния час",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Последните 24 часа",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Последните 7 дни",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Последните 4 седмици",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "През цялото време",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {един час} day {24 часа} week {една седмица} month {4 седмици} other {Всички}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Затваряне на <b>{openTabs}</b> раздел и изчистване на <b>{durationDesc}</b> от историята на сърфиране и бисквитките?} other {Затваряне на <b>{openTabs}</b> раздела и изчистване на <b>{durationDesc}</b> от историята на сърфиране и бисквитките?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Затваряне на <b>{openTabs}</b> раздел и изтриване на <b>{durationDesc}</b> от историята на сърфиране и бисквитките?} other {Затваряне на <b>{openTabs}</b> раздела и изтриване на <b>{durationDesc}</b> от историята на сърфиране и бисквитките?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Затваряне на <b>{openTabs}</b> раздел и изчистване на <b>{durationDesc}</b> от бисквитките?} other {Затваряне на <b>{openTabs}</b> раздела и изчистване на <b>{durationDesc}</b> от бисквитките?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Затваряне на <b>{openTabs}</b> раздел и изтриване на <b>{durationDesc}</b> от бисквитките?} other {Затваряне на <b>{openTabs}</b> раздела и изтриване на <b>{durationDesc}</b> от бисквитките?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Изчистване на <b>{durationDesc}</b> от историята на сърфиране и бисквитките?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Изтриване на <b>{durationDesc}</b> от историята на сърфиране и бисквитките?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Изчистване на <b>{durationDesc}</b> от бисквитките?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Изтриване на <b>{durationDesc}</b> от бисквитките?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Затваряне на <b>{openTabs}</b> {openTabs, plural, =1 {раздел} other {раздела}} и изчистване на <b>цялата</b> история на сърфиране и всички бисквитки ({cookies} {cookies, plural, =1 {сайт} other {сайта}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Затваряне на <b>{openTabs}</b> {openTabs, plural, =1 {раздел} other {раздела}} и изтриване на <b>цялата</b> история на сърфиране и всички бисквитки ({cookies} {cookies, plural, =1 {сайт} other {сайта}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Затваряне на <b>{openTabs}</b> {openTabs, plural, =1 {раздел} other {раздела}} и изчистване на <b>всички</b> бисквитки ({cookies} {cookies, plural, =1 {сайта} other {сайта}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Затваряне на <b>{openTabs}</b> {openTabs, plural, =1 {раздел} other {раздела}} и изтриване на <b>всички</b> бисквитки ({cookies} {cookies, plural, =1 {сайта} other {сайта}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Изчистване на <b>цялата</b> история на сърфиране и бисквитките ({cookies} сайт)?} other {Изчистване на <b>цялата</b> история на сърфиране и бисквитките ({cookies} сайта)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Изтриване на <b>цялата</b> история на сърфиране и бисквитките ({cookies} сайт)?} other {Изтриване на <b>цялата</b> история на сърфиране и бисквитките ({cookies} сайта)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Изчистване на <b>всички</b> бисквитки ({cookies} сайт)?} other {Изчистване на <b>всички</b> бисквитки ({cookies} сайта)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Изтриване на <b>всички</b> бисквитки ({cookies} сайт)?} other {Изтриване на <b>всички</b> бисквитки ({cookies} сайта)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Затваряне на <b>{openTabs} раздел {site}</b> и изчистване на <b>всички бисквитки за {site}</b>?} other {Затваряне на <b>{openTabs} раздела {site}</b> и изчистване на <b>всички бисквитки за {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Затваряне на <b>{openTabs} раздел {site}</b> и изтриване на <b>всички бисквитки за {site}</b>?} other {Затваряне на <b>{openTabs} раздела {site}</b> и изтриване на <b>всички бисквитки за {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Затваряне на <b>{openTabs} раздел {site}</b> и изчистване на <b>всички бисквитки за {site}</b>?} other {Затваряне на <b>{openTabs} раздела {site}</b> и изчистване на <b>всички бисквитки за {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Затваряне на <b>{openTabs} раздел {site}</b> и изтриване на <b>всички бисквитки за {site}</b>?} other {Затваряне на <b>{openTabs} раздела {site}</b> и изтриване на <b>всички бисквитки за {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Изчистване на <b>цялата история на сърфиране и всички бисквитки за {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Изтриване на <b>цялата история на сърфиране и всички бисквитки за {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Изчистване на <b>всички бисквитки за {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Изтриване на <b>всички бисквитки за {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} закачен</b> раздел ще бъде игнориран.} other {<b>{tabs} закачени</b> раздела ще бъдат игнорирани.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Ясно",
-    "note": "Button text to start data clearing."
+    "title": "Изтриване",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Отмени",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Това ще нулира направените настройки за търсене.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Научете повече",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "За да изчистите и историята, изберете период от време.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "За да изтриете и историята, изберете период от време.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/cs/firebutton.json
+++ b/shared/locales/cs/firebutton.json
@@ -10,103 +10,111 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Zavřít karty a vymazat data",
+    "title": "Zavřít karty a smazat data",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Vymazat data",
+    "title": "Smazat data",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Jen aktuální stránka",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Poslední hodina",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Posledních 24 hodin",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Posledních 7 dní",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Poslední 4 týdny",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Po celou dobu",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {jednu hodinu} day {24 hodin} week {jeden týden} month {4 týdny} other {Vše}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Zavřít <b>{openTabs}</b> kartu a vymazat <b>{durationDesc}</b> historie procházení a souborů cookie?} few {Zavřít <b>{openTabs}</b> karty a vymazat <b>{durationDesc}</b> historie procházení a souborů cookie?} many {Zavřít <b>{openTabs}</b> karty a vymazat <b>{durationDesc}</b> historie procházení a souborů cookie?} other {Zavřít <b>{openTabs}</b> karet a vymazat <b>{durationDesc}</b> historie procházení a souborů cookie?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Zavřít <b>{openTabs}</b> kartu a smazat <b>{durationDesc}</b> historie procházení a souborů cookie?} few {Zavřít <b>{openTabs}</b> karty a smazat <b>{durationDesc}</b> historie procházení a souborů cookie?} many {Zavřít <b>{openTabs}</b> karty a smazat <b>{durationDesc}</b> historie procházení a souborů cookie?} other {Zavřít <b>{openTabs}</b> karet a smazat <b>{durationDesc}</b> historie procházení a souborů cookie?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Zavřít <b>{openTabs}</b> kartu a vymazat <b>{durationDesc}</b> souborů cookie?} few {Zavřít <b>{openTabs}</b> karty a vymazat <b>{durationDesc}</b> souborů cookie?} many {Zavřít <b>{openTabs}</b> karty a vymazat <b>{durationDesc}</b> souborů cookie?} other {Zavřít <b>{openTabs}</b> karet a vymazat <b>{durationDesc}</b> souborů cookie?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Zavřít <b>{openTabs}</b> kartu a smazat <b>{durationDesc}</b> souborů cookie?} few {Zavřít <b>{openTabs}</b> karty a smazat <b>{durationDesc}</b> souborů cookie?} many {Zavřít <b>{openTabs}</b> karty a smazat <b>{durationDesc}</b> souborů cookie?} other {Zavřít <b>{openTabs}</b> karet a smazat <b>{durationDesc}</b> souborů cookie?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Vymazat <b>{durationDesc}</b> historie procházení a souborů cookie?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Smazat <b>{durationDesc}</b> historie procházení a souborů cookie?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Vymazat <b>{durationDesc}</b> souborů cookie?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Smazat <b>{durationDesc}</b> souborů cookie?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Zavřít <b>{openTabs}</b> {openTabs, plural, =1 {záložku} few {záložky} other {záložek}} a vymazat <b>veškerou</b> historii procházení a všechny soubory cookie ({cookies} {cookies, plural, =1 {stránka} few {stránky} other {stránek}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Zavřít <b>{openTabs}</b> {openTabs, plural, =1 {záložku} few {záložky} other {záložek}} a smazat <b>veškerou</b> historii procházení a všechny soubory cookie ({cookies} {cookies, plural, =1 {stránka} few {stránky} other {stránek}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Zavřít <b>{openTabs}</b> {openTabs, plural, =1 {záložku} few {záložky} other {záložek}} a vymazat <b>všechny</b> soubory cookie ({cookies} {cookies, plural, =1 {stránka} few {stránky} other {stránek}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Zavřít <b>{openTabs}</b> {openTabs, plural, =1 {záložku} few {záložky} other {záložek}} a smazat <b>všechny</b> soubory cookie ({cookies} {cookies, plural, =1 {stránka} few {stránky} other {stránek}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Vymazat <b>veškerou</b> historii prohlížení a všechny soubory cookie ({cookies} stránka)?} few {Vymazat <b>veškerou</b> historii prohlížení a všechny soubory cookie ({cookies} stránky)?} many {Vymazat <b>veškerou</b> historii prohlížení a všechny soubory cookie ({cookies} stránky)?} other {Vymazat <b>veškerou</b> historii prohlížení a všechny soubory cookie ({cookies} stránek)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Smazat <b>veškerou</b> historii prohlížení a všechny soubory cookie ({cookies} stránka)?} few {Smazat <b>veškerou</b> historii prohlížení a všechny soubory cookie ({cookies} stránky)?} many {Smazat <b>veškerou</b> historii prohlížení a všechny soubory cookie ({cookies} stránky)?} other {Smazat <b>veškerou</b> historii prohlížení a všechny soubory cookie ({cookies} stránek)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Vymazat <b>všechny</b> soubory cookie ({cookies} stránka)?} few {Vymazat <b>všechny</b> soubory cookie ({cookies} stránky)?} many {Vymazat <b>všechny</b> soubory cookie ({cookies} stránky)?} other {Vymazat <b>všechny</b> soubory cookie ({cookies} stránek)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Smazat <b>všechny</b> soubory cookie ({cookies} stránka)?} few {Smazat <b>všechny</b> soubory cookie ({cookies} stránky)?} many {Smazat <b>všechny</b> soubory cookie ({cookies} stránky)?} other {Smazat <b>všechny</b> soubory cookie ({cookies} stránek)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Zavřít <b>{openTabs} kartu {site}</b> a vymazat <b>všechny soubory cookie ze stránky {site}</b>?} few {Zavřít <b>{openTabs} karty {site}</b> a vymazat <b>všechny soubory cookie ze stránky {site}</b>?} many {Zavřít <b>{openTabs} karty {site}</b> a vymazat <b>všechny soubory cookie ze stránky {site}</b>?} other {Zavřít <b>{openTabs} karet {site}</b> a vymazat <b>všechny soubory cookie ze stránky {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Zavřít <b>{openTabs} kartu {site}</b> a smazat <b>všechny soubory cookie ze stránky {site}</b>?} few {Zavřít <b>{openTabs} karty {site}</b> a smazat <b>všechny soubory cookie ze stránky {site}</b>?} many {Zavřít <b>{openTabs} karty {site}</b> a smazat <b>všechny soubory cookie ze stránky {site}</b>?} other {Zavřít <b>{openTabs} karet {site}</b> a smazat <b>všechny soubory cookie ze stránky {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Zavřít <b>{openTabs} kartu {site}</b> a vymazat <b>všechny soubory cookie ze stránky {site}</b>?} few {Zavřít <b>{openTabs} karty {site}</b> a vymazat <b>všechny soubory cookie ze stránky {site}</b>?} many {Zavřít <b>{openTabs} karty {site}</b> a vymazat <b>všechny soubory cookie ze stránky {site}</b>?} other {Zavřít <b>{openTabs} karet {site}</b> a vymazat <b>všechny soubory cookie ze stránky {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Zavřít <b>{openTabs} kartu {site}</b> a smazat <b>všechny soubory cookie ze stránky {site}</b>?} few {Zavřít <b>{openTabs} karty {site}</b> a smazat <b>všechny soubory cookie ze stránky {site}</b>?} many {Zavřít <b>{openTabs} karty {site}</b> a smazat <b>všechny soubory cookie ze stránky {site}</b>?} other {Zavřít <b>{openTabs} karet {site}</b> a smazat <b>všechny soubory cookie ze stránky {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Vymazat <b>celou historii prohlížení a soubory cookie ze stránky {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Smazat <b>celou historii prohlížení a soubory cookie ze stránky {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Vymazat <b>všechny soubory cookie ze stránky {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Smazat <b>všechny soubory cookie ze stránky {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} připnutá</b> karta bude ignorována.} few {<b>{tabs} připnuté</b> karty budou ignorovány.} many {<b>{tabs} připnuté</b> karty bude ignorováno.} other {<b>{tabs} připnutých</b> karet bude ignorováno.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Vymazat",
-    "note": "Button text to start data clearing."
+    "title": "Smazat",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Zrušit",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Tímhle krokem se resetuje tvoje nastavení vyhledávání.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Více informací",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Pokud chceš vymazat i historii, vyber časové období.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Pokud chceš smazat i historii, vyber časové období.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/da/firebutton.json
+++ b/shared/locales/da/firebutton.json
@@ -10,103 +10,111 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Luk faner og ryd data",
+    "title": "Luk faner, og slet data",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Ryd data",
+    "title": "Slet data",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Kun aktuelt websted",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Sidste time",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Sidste 24 timer",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "De seneste 7 dage",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "De seneste 4 uger",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Altid",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {en time} day {24 timer} week {en uge} month {4 uger} other {Alle}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs}</b> fane og rydde <b>{durationDesc}</b>s browserhistorik og cookies?} other {Vil du lukke <b>{openTabs}</b> faner og rydde <b>{durationDesc}</b>s browserhistorik og cookies?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs}</b> fane og slette <b>{durationDesc}</b>s browserhistorik og cookies?} other {Vil du lukke <b>{openTabs}</b> faner og slette <b>{durationDesc}</b>s browserhistorik og cookies?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
     "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs}</b> fane og rydde <b>{durationDesc}</b>s cookies?} other {Vil du lukke <b>{openTabs}</b> faner og rydde <b>{durationDesc}</b>s cookies?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Vil du rydde browserhistorik og cookies for de seneste <b>{durationDesc}</b>?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Vil du slette <b>{durationDesc}</b>s browserhistorik og cookies?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Vil du rydde cookies for de seneste <b>{durationDesc}</b>?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Vil du slette <b>{durationDesc}</b>s cookies?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Luk <b>{openTabs}</b> {openTabs, plural, =1 {fane} other {faner}}, og ryd <b>al</b> browserhistorik og alle cookies ({cookies} {cookies, plural, =1 {websted} other {websteder}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Luk <b>{openTabs}</b> {openTabs, plural, =1 {fane} other {faner}}, og slet <b>al</b> browserhistorik og alle cookies ({cookies} {cookies, plural, =1 {websted} other {websteder}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
     "title": "Luk <b>{openTabs}</b> {openTabs, plural, =1 {fane} other {faner}}, og slet <b>alle</b> cookies ({cookies} {cookies, plural, =1 {websted} other {websteder}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Ryd <b>al</b> browserhistorik og cookies ({cookies} websted)?} other {Ryd <b>al</b> browserhistorik og cookies ({cookies} websteder)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Ryd <b>al</b> browserhistorik og alle cookies ({cookies} websted)?} other {Ryd <b>al</b> browserhistorik og alle cookies ({cookies} websteder)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Vil du rydde <b>alle</b> cookies ({cookies} websted)?} other {Vil du rydde <b>alle</b> cookies ({cookies} websteder)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Vil du slette <b>alle</b> cookies ({cookies} websted)?} other {Vil du slette <b>alle</b> cookies ({cookies} websteder)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs} fane {site}</b> og rydde <b>alle {site}</b> cookies?} other {Vil du lukke <b>{openTabs} faner {site}</b> og rydde <b>alle {site}</b> cookies?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs} fane på {site}</b> og slette <b>alle {site}</b>-cookies?} other {Vil du lukke <b>{openTabs} faner på {site}</b> og slette <b>alle {site}</b>-cookies?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs} fane {site}</b> og rydde <b>alle {site}</b> cookies?} other {Vil du lukke <b>{openTabs} faner {site}</b> og rydde <b>alle {site}</b> cookies?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs} fane på {site}</b> og slette <b>alle {site}</b>-cookies?} other {Vil du lukke <b>{openTabs} faner på {site}</b> og slette <b>alle {site}</b>-cookies?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Vil du rydde al browserhistorik og alle cookies for <b>{site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Slet <b>al {site}</b> browserhistorik og alle cookies?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Vil du rydde alle cookies for <b>{site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Vil du rydde <b>alle {site}</b>-cookies?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} fastgjort</b> fane ignoreres.} other {<b>{tabs} fastgjorte</b> faner ignoreres.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Nulstil",
-    "note": "Button text to start data clearing."
+    "title": "Slet",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Annullér",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Dette vil nulstille dine søgeindstillinger.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Mere info",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Vælg en tidsperiode for også at rydde historikken.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Vælg en tidsperiode for også at slette historikken.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/de/firebutton.json
+++ b/shared/locales/de/firebutton.json
@@ -19,27 +19,27 @@
   },
   "optionCurrentSite": {
     "title": "Nur aktuelle Website",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Letzte Stunde",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Letzte 24 Stunden",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Letzte 7 Tage",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Letzte 4 Wochen",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Alle Zeiten",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {eine Stunde} day {24 Stunden} week {eine Woche} month {4 Wochen} other {Alle}}",
@@ -47,51 +47,51 @@
   },
   "summaryClearTabsHistoryDuration": {
     "title": "{openTabs, plural, one {<b>{openTabs}</b> Tab schließen und <b>{durationDesc}</b> Browserverlauf und Cookies löschen?} other {<b>{openTabs}</b> Tabs schließen und <b>{durationDesc}</b> Browserverlauf und Cookies löschen?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
     "title": "{openTabs, plural, one {<b>{openTabs}</b> Tab schließen und <b>{durationDesc}</b> Cookies löschen?} other {<b>{openTabs}</b> Tabs schließen und <b>{durationDesc}</b> Cookies löschen?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
     "title": "<b>{durationDesc}</b> Browserverlauf und Cookies löschen?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
     "title": "<b>{durationDesc}</b> Cookies löschen?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
     "title": "Schließen Sie <b>{openTabs}</b> {openTabs, plural, =1 {Tab} other {Tabs}} und löschen Sie <b>alle</b> Browserverläufe und Cookies ({cookies} {cookies, plural, =1 {Website} other {Websites}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
     "title": "Schließen Sie <b>{openTabs}</b> {openTabs, plural, =1 {Tab} other {Tabs}} und löschen Sie <b>alle</b> Cookies ({cookies} {cookies, plural, =1 {Website} other {Websites}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Den <b>gesamten Browserverlauf und alle</b> Cookies löschen ({cookies} Website)?} other {Den <b>gesamten Browserverlauf und alle</b> Cookies löschen ({cookies} Websites)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {<b>Alle</b> Browserverläufe und Cookies löschen ({cookies} Website)?} other {<b>Alle</b> Browserverläufe und Cookies löschen ({cookies} Websites)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
     "title": "{cookies, plural, one {<b>Alle</b> Cookies löschen ({cookies} Website)?} other {<b>Alle</b> Cookies löschen ({cookies} Websites)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {<b>{openTabs} {site}</b> Tab schließen und <b>alle {site}</b> Cookies löschen?} other {<b>{openTabs} {site}</b> Tabs schließen und <b>alle {site}</b> Cookies löschen?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {{openTabs} <b>{site}</b> Tab schließen und <b>alle {site}</b> Cookies löschen?} other {{openTabs} <b>{site}</b> Tabs schließen und <b>alle {site}</b> Cookies löschen?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
     "title": "{openTabs, plural, one {<b>{openTabs} {site}</b> Tab schließen und <b>alle {site}</b> Cookies löschen?} other {<b>{openTabs} {site}</b> Tabs schließen und <b>alle {site}</b> Cookies löschen?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
     "title": "<b>Alle {site}</b> Browserverläufe und Cookies löschen?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "<b>Alle {site}</b> Cookies löschen?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Alle <b> {site}</b> Cookies löschen?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} angeheftetes</b> Tab wird ignoriert.} other {<b>{tabs} angeheftete</b> Tabs werden ignoriert.}}",
@@ -99,14 +99,22 @@
   },
   "clearData": {
     "title": "Löschen",
-    "note": "Button text to start data clearing."
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Abbrechen",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Dadurch werden Ihre Sucheinstellungen zurückgesetzt.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Mehr erfahren",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
     "title": "Um auch den Verlauf zu löschen, wählen Sie einen Zeitraum aus.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/el/firebutton.json
+++ b/shared/locales/el/firebutton.json
@@ -10,36 +10,36 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Κλείσιμο καρτελών και εκκαθάριση δεδομένων",
+    "title": "Κλείσιμο καρτελών και διαγραφή δεδομένων",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Εκκαθάριση δεδομένων",
+    "title": "Διαγραφή δεδομένων",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Μόνο ο τρέχων ιστότοπος",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Τελευταία ώρα",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Τελευταίες 24 ώρες",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Τελευταίες 7 ημέρες",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Τελευταίες 4 εβδομάδες",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Όλο",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {μία ώρα} day {24 ώρες} week {μία βδομάδα} month {4 εβδομάδες} other {Όλα}}",
@@ -47,51 +47,51 @@
   },
   "summaryClearTabsHistoryDuration": {
     "title": "{openTabs, plural, one {Θέλετε να κλείσετε <b>{openTabs}</b> καρτέλα και να διαγράψετε <b>{durationDesc}</b> του ιστορικού περιήγησης και των cookies;} other {Θέλετε να κλείσετε <b>{openTabs}</b> καρτέλες και να διαγράψετε <b>{durationDesc}</b> του ιστορικού περιήγησης και των cookies;}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
     "title": "{openTabs, plural, one {Θέλετε να κλείσετε <b>{openTabs}</b> καρτέλα και να διαγράψετε <b>{durationDesc}</b> από τα cookies;} other {Θέλετε να κλείσετε <b>{openTabs}</b> καρτέλες και να διαγράψετε <b>{durationDesc}</b> από τα cookies;}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
     "title": "Θέλετε να διαγράψετε <b>{durationDesc}</b> από το ιστορικό περιήγησης και τα cookies;",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
     "title": "Θέλετε να διαγράψετε <b>{durationDesc}</b> από τα cookies;",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
     "title": "Θέλετε να κλείσετε <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}} και να διαγράψετε <b>όλο</b> το ιστορικό περιήγησης και τα cookies ({cookies} {cookies, plural, =1 {site} other {sites}});",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
     "title": "Θέλετε να κλείσετε <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}} και να διαγράψετε <b>όλα</b> τα cookies ({cookies} {cookies, plural, =1 {site} other {sites}});",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
     "title": "{cookies, plural, one {Θέλετε να διαγράψετε <b>όλο</b> το ιστορικό περιήγησης και τα cookies ({cookies} ιστότοπος);} other {Θέλετε να διαγράψετε <b>όλο</b> το ιστορικό περιήγησης και τα cookies ({cookies} ιστότοποι);}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
     "title": "{cookies, plural, one {Θέλετε να διαγράψετε <b>όλα</b> τα cookies ({cookies} ιστότοπος);} other {Θέλετε να διαγράψετε <b>όλα</b> τα cookies ({cookies} ιστότοποι);}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Θέλετε να κλείσετε <b>{openTabs} {site}</b> καρτέλα και να διαγράψτε <b>όλα τα cookies του {site}</b>;} other {Θέλετε να κλείσετε <b>{openTabs} {site}</b> καρτέλες και να διαγράψτε <b>όλα τα cookies του {site}</b>;}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Θέλετε να κλείσετε την καρτέλα <b>{openTabs} {site}</b> και να διαγράψτε <b>όλα τα cookies του {site}</b>;} other {Θέλετε να κλείσετε <b>{openTabs} {site}</b> καρτέλες και να διαγράψτε <b>όλα τα cookies του {site}</b>;}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
     "title": "{openTabs, plural, one {Θέλετε να κλείσετε την καρτέλα <b>{openTabs} {site}</b> και να διαγράψτε <b>όλα τα cookies του {site}</b>;} other {Θέλετε να κλείσετε <b>{openTabs} {site}</b> καρτέλες και να διαγράψτε <b>όλα τα cookies του {site}</b>;}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
     "title": "Θέλετε να διαγράψετε <b> όλο το ιστορικό περιήγησης του {site}</b> και τα cookies;",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
     "title": "Θέλετε να διαγράψετε <b>όλα τα cookies του {site}</b>;",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} καρφιτσωμένη</b> καρτέλα θα αγνοηθεί.} other {<b>{tabs} καρφιτσωμένες</b> καρτέλες θα αγνοηθούν.}}",
@@ -99,14 +99,22 @@
   },
   "clearData": {
     "title": "Διαγραφή",
-    "note": "Button text to start data clearing."
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Ακύρωση",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Αυτό θα επαναφέρει τις ρυθμίσεις Αναζήτησης.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Μάθετε περισσότερα",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
     "title": "Για να διαγράψετε επίσης το ιστορικό, επιλέξτε μια χρονική περίοδο.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/en/firebutton.json
+++ b/shared/locales/en/firebutton.json
@@ -8,111 +8,111 @@
         }]
     },
     "fireDialogHeader": {
-        "title": "Close Tabs and Clear Data",
+        "title": "Close Tabs and Delete Data",
         "note": "Dialog header."
     },
     "fireDialogHeaderNoTabs": {
-        "title": "Clear Data",
+        "title": "Delete Data",
         "note": "Dialog header when tab clearing is disabled."
     },
     "optionCurrentSite": {
         "title": "Current site only",
-        "note": "Dropdown option to only clear data for the current active website"
+        "note": "Dropdown option to only delete data for the current active website"
     },
     "optionLastHour": {
         "title": "Last hour",
-        "note": "Dropdown option to only clear data from the past hour"
+        "note": "Dropdown option to only delete data from the past hour"
     },
     "optionLast24Hour": {
         "title": "Last 24 hours",
-        "note": "Dropdown option to only clear data from the past 24 hours"
+        "note": "Dropdown option to only delete data from the past 24 hours"
     },
     "optionLast7days": {
         "title": "Last 7 days",
-        "note": "Dropdown option to only clear data from the past 7 days"
+        "note": "Dropdown option to only delete data from the past 7 days"
     },
     "optionLast4Weeks": {
         "title": "Last 4 weeks",
-        "note": "Dropdown option to only clear data from the past 4 weeks"
+        "note": "Dropdown option to only delete data from the past 4 weeks"
     },
     "optionAllTime": {
         "title": "All time",
-        "note": "Dropdown option to clear all data, since recording started"
+        "note": "Dropdown option to delete all data, since recording started"
     },
     "historyDuration": {
         "title": "{duration, select, hour {one hour} day {24 hours} week {one week} month {4 weeks} other {all} }",
         "note": "Description of what period of history data should be deleted."
     },
     "summaryClearTabsHistoryDuration": {
-        "title": "Close <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}}, and clear <b>{durationDesc}</b> of browsing history and cookies?",
-        "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+        "title": "Close <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}}, and delete <b>{durationDesc}</b> of browsing history and cookies?",
+        "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
     },
     "summaryClearTabsDuration": {
-        "title": "Close <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}}, and clear <b>{durationDesc}</b> of cookies?",
-        "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+        "title": "Close <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}}, and delete <b>{durationDesc}</b> of cookies?",
+        "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
     },
     "summaryClearHistoryDuration": {
-        "title": "Clear <b>{durationDesc}</b> of browsing history and cookies?",
-        "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+        "title": "Delete <b>{durationDesc}</b> of browsing history and cookies?",
+        "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
     },
     "summaryClearCookiesDuration": {
-        "title": "Clear <b>{durationDesc}</b> of cookies?",
-        "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+        "title": "Delete <b>{durationDesc}</b> of cookies?",
+        "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
     },
     "summaryClearTabsHistoryAll": {
-        "title": "Close <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}}, and clear <b>all</b> browsing history and cookies ({cookies} {cookies, plural, =1 {site} other {sites}})?",
-        "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+        "title": "Close <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}}, and delete <b>all</b> browsing history and cookies ({cookies} {cookies, plural, =1 {site} other {sites}})?",
+        "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
     },
     "summaryClearTabsAll": {
-        "title": "Close <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}}, and clear <b>all</b> cookies ({cookies} {cookies, plural, =1 {site} other {sites}})?",
-        "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+        "title": "Close <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}}, and delete <b>all</b> cookies ({cookies} {cookies, plural, =1 {site} other {sites}})?",
+        "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
     },
     "summaryClearHistoryAll": {
-        "title": "Clear <b>all</b> browsing history and cookies ({cookies} {cookies, plural, =1 {site} other {sites}})?",
-        "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+        "title": "Delete <b>all</b> browsing history and cookies ({cookies} {cookies, plural, =1 {site} other {sites}})?",
+        "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
     },
     "summaryClearCookiesAll": {
-        "title": "Clear <b>all</b> cookies ({cookies} {cookies, plural, =1 {site} other {sites}})?",
-        "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+        "title": "Delete <b>all</b> cookies ({cookies} {cookies, plural, =1 {site} other {sites}})?",
+        "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
     },
     "summaryClearTabsHistorySite": {
-        "title": "Close <b>{openTabs} {site}</b> {openTabs, plural, =1 {tab} other {tabs}}, and clear <b>all {site}</b> cookies?",
-        "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+        "title": "Close <b>{openTabs} {site}</b> {openTabs, plural, =1 {tab} other {tabs}}, and delete <b>all {site}</b> cookies?",
+        "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
     },
     "summaryClearTabsSite": {
-        "title": "Close <b>{openTabs} {site}</b> {openTabs, plural, =1 {tab} other {tabs}}, and clear <b>all {site}</b> cookies?",
-        "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+        "title": "Close <b>{openTabs} {site}</b> {openTabs, plural, =1 {tab} other {tabs}}, and delete <b>all {site}</b> cookies?",
+        "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
     },
     "summaryClearHistorySite": {
-        "title": "Clear <b>all {site}</b> browsing history and cookies?",
-        "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+        "title": "Delete <b>all {site}</b> browsing history and cookies?",
+        "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
     },
     "summaryClearCookiesSite": {
-        "title": "Clear <b>all {site}</b> cookies?",
-        "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+        "title": "Delete <b>all {site}</b> cookies?",
+        "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
     },
     "summaryPinnedIgnored": {
         "title": "<b>{tabs} pinned</b> {tabs, plural, =1 {tab} other {tabs}} will be ignored.",
         "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
     },
     "clearData": {
-        "title": "Clear",
-        "note": "Button text to start data clearing."
+        "title": "Delete",
+        "note": "Button text to start data deletion."
     },
     "cancel": {
         "title": "Cancel",
         "note": "Button text to exit the fire button modal."
     },
     "clearingCookiesWarning": {
-        "title": "Clearing cookies will reset your Search preferences.",
-        "note": "Warning message shown when clearing cookies for a specific site, informing the user that their search preferences will be reset."
+        "title": "This will reset your Search settings.",
+        "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
     },
     "learnMore": {
-        "title": "Learn more",
-        "note": "Link text that opens a help page with more information about clearing cookies and search preferences."
+        "title": "Learn More",
+        "note": "Link text that opens a help page with more information about deleting cookies and search settings."
     },
     "historyAndDownloadsNotAffected": {
-        "title": "To also clear history, select a time period.",
-        "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+        "title": "To also delete history, select a time period.",
+        "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
     }
 }

--- a/shared/locales/en/firebutton.json
+++ b/shared/locales/en/firebutton.json
@@ -103,6 +103,14 @@
         "title": "Cancel",
         "note": "Button text to exit the fire button modal."
     },
+    "clearingCookiesWarning": {
+        "title": "Clearing cookies will reset your Search preferences.",
+        "note": "Warning message shown when clearing cookies for a specific site, informing the user that their search preferences will be reset."
+    },
+    "learnMore": {
+        "title": "Learn more",
+        "note": "Link text that opens a help page with more information about clearing cookies and search preferences."
+    },
     "historyAndDownloadsNotAffected": {
         "title": "To also clear history, select a time period.",
         "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."

--- a/shared/locales/es/firebutton.json
+++ b/shared/locales/es/firebutton.json
@@ -14,32 +14,32 @@
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Borrar datos",
+    "title": "Eliminar datos",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Solo sitio actual",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Última hora",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Últimas 24 horas",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Últimos 7 días",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Últimas 4 semanas",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Siempre",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {una hora} day {24 horas} week {una semana} month {4 semanas} other {Todo}}",
@@ -47,66 +47,74 @@
   },
   "summaryClearTabsHistoryDuration": {
     "title": "{openTabs, plural, one {¿Cerrar <b>{openTabs}</b> pestaña y borrar <b>{durationDesc}</b> del historial de navegación y las cookies?} other {¿Cerrar <b>{openTabs}</b> pestañas y borrar <b>{durationDesc}</b> del historial de navegación y las cookies?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
     "title": "{openTabs, plural, one {¿Cerrar <b>{openTabs}</b> pestaña y borrar <b>{durationDesc}</b> de las cookies?} other {¿Cerrar <b>{openTabs}</b> pestañas y borrar <b>{durationDesc}</b> de las cookies?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
     "title": "¿Borrar <b>{durationDesc}</b> del historial de navegación y las cookies?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "¿Borrar <b>{durationDesc}</b> de las cookies?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "¿Eliminar <b>{durationDesc}</b> de cookies?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
     "title": "¿Cerrar <b>{openTabs}</b> {openTabs, plural, =1 {pestaña} other {pestañas}} y borrar <b>todo</b> el historial de navegación y cookies ({cookies} {cookies, plural, =1 {sitio} other {sitios}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
     "title": "¿Cerrar <b>{openTabs}</b> {openTabs, plural, =1 {pestaña} other {pestañas}} y borrar <b>todas</b> las cookies ({cookies} {cookies, plural, =1 {sitios} other {sitios}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {¿Borrar <b>todo</b> el historial de navegación y las cookies ({cookies} sitios)?} other {¿Borrar <b>todo</b> el historial de navegación y las cookies (sitios de {cookies})?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {¿Eliminar <b>todo</b> el historial de navegación y las cookies ({cookies} sitio)?} other {¿Eliminar <b>todo</b> el historial de navegación y las cookies ({cookies} sitios)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {¿Borrar <b>todas</b> las cookies (sitio de {cookies})?} other {¿Borrar <b>todas</b> las cookies (sitios de {cookies})?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {¿Eliminar <b>todas</b> las cookies ({cookies} sitio)?} other {¿Eliminar <b>todas</b> las cookies ({cookies} sitios)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {¿Cerrar <b>{site} {openTabs}</b> pestaña y borrar <b>todas las cookies de {site}</b>?} other {¿Cerrar <b>{site} {openTabs} </b> pestañas y borrar <b>todas las cookies de {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {¿Cerrar <b>{openTabs} {site}</b> pestaña y borrar <b>todas las cookies de {site}</b>?} other {¿Cerrar <b>{openTabs} {site}</b> pestañas y borrar <b>todas las cookies de {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {¿Cerrar <b>{openTabs} pestaña de {site}</b> y borrar <b>todas las cookies de {site}</b>?} other {¿Cerrar <b>{openTabs} pestañas de {site}</b> y borrar <b>todas las cookies de {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {¿Cerrar <b>{site}{openTabs} </b> pestaña y borrar <b>todas las cookies de {site}</b>?} other {¿Cerrar <b>{openTabs} {site}</b> pestañas y borrar <b>todas las cookies de {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "¿Borrar <b>todo el historial de navegación y las cookies de {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "¿Eliminar <b>todo el historial de navegación y las cookies de {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
     "title": "¿Borrar <b>todas las cookies de {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {Se ignorará <b>{tabs} pestaña anclada</b>.} other {Se ignorarán<b>{tabs} pestañas ancladas</b>.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Borrar",
-    "note": "Button text to start data clearing."
+    "title": "Eliminar",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Cancelar",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Esto restablecerá tus ajustes de búsqueda.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Más información",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
     "title": "Para borrar también el historial, selecciona un periodo de tiempo.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/et/firebutton.json
+++ b/shared/locales/et/firebutton.json
@@ -14,99 +14,107 @@
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Kustuta andmed",
+    "title": "Andmete kustutamine",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Ainult praegune sait",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Viimane tund",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Viimased 24 tundi",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Viimased 7 päeva",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Viimased 4 nädalat",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Kogu aeg",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {ühe tunni} day {24 tunni} week {ühe nädala} month {4 nädala} other {Kõik}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Kas sulgeda <b>{openTabs}</b> vahekaart ning kustutada <b>{durationDesc}</b> sirvimisajalugu ja küpsised?} other {Kas sulgeda <b>{openTabs}</b> vahekaarti ning kustutada <b>{durationDesc}</b> sirvimisajalugu ja küpsised?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Kas sulgeda <b>{openTabs}</b> vahekaart ja kustutada <b>{durationDesc}</b> sirvimisajalugu ja küpsised?} other {Kas sulgeda <b>{openTabs}</b> vahekaarti ja kustutada <b>{durationDesc}</b> sirvimisajalugu ja küpsised?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
     "title": "{openTabs, plural, one {Kas sulgeda <b>{openTabs}</b> vahekaart ja kustutada <b>{durationDesc}</b> küpsised?} other {Kas sulgeda <b>{openTabs}</b> vahekaarti ja kustutada <b>{durationDesc}</b> küpsised?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
     "title": "Kas kustutada <b>{durationDesc}</b> sirvimisajalugu ja küpsised?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
     "title": "Kas kustutada <b>{durationDesc}</b> küpsised?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Kas sulgeda <b>{openTabs}</b> {openTabs, plural, =1 {vahekaart} other {vahekaarti}} ning kustutada <b>kogu</b> sirvimisajalugu ja küpsised ({cookies} {cookies, plural, =1 {saidil} other {saidil}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Kas sulgeda <b>{openTabs}</b> {openTabs, plural, =1 {tab} muu {tabs}} ja kustutada <b>kogu</b> sirvimisajalugu ja küpsised ({cookies} {cookies, plural, =1 {site} muu {sites}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Kas sulgeda <b>{openTabs}</b> {openTabs, plural, =1 {vahekaart} other {vahekaarti}} ja kustutada <b>kõik</b> küpsised ({cookies} {cookies, plural, =1 {saidil} other {saidil}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Kas sulgeda <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}} ja kustutada <b>kõik</b> küpsised ({cookies} {cookies, plural, =1 {site} muu {sites}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
     "title": "{cookies, plural, one {Kas kustutada <b>kogu</b> sirvimisajalugu ja küpsised ({cookies} saidil)?} other {Kas kustutada <b>kogu</b> sirvimisajalugu ja küpsised ({cookies} saidil)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
     "title": "{cookies, plural, one {Kas kustutada <b>kõik</b> küpsised ({cookies} saidil)?} other {Kas kustutada <b>kõik</b> küpsised ({cookies} saidil)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
     "title": "{openTabs, plural, one {Kas sulgeda <b>{openTabs} {site}</b> vahekaart ja kustutada <b>kõik saidi {site}</b> küpsised?} other {Kas sulgeda <b>{openTabs} {site}</b> vahekaarti ja kustutada <b>kõik saidi {site}</b> küpsised?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
     "title": "{openTabs, plural, one {Kas sulgeda <b>{openTabs} {site}</b> vahekaart ja kustutada <b>kõik saidi {site}</b> küpsised?} other {Kas sulgeda <b>{openTabs} {site}</b> vahekaarti ja kustutada <b>kõik saidi {site}</b> küpsised?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
     "title": "Kas kustutada <b>kogu saidi {site}</b> sirvimisajalugu ja küpsised?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
     "title": "Kas kustutada <b>kõik saidi {site}</b> küpsised?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {Eiratakse <b>{tabs} kinnitatud</b> vahekaarti.} other {Eiratakse <b>{tabs} kinnitatud</b> vahekaarti.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Tühjenda",
-    "note": "Button text to start data clearing."
+    "title": "Kustuta",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Tühista",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "See lähtestab sinu otsingu seaded.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Loe edasi",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
     "title": "Vali ajaloo kustutamiseks periood.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/et/firebutton.json
+++ b/shared/locales/et/firebutton.json
@@ -62,11 +62,11 @@
     "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Kas sulgeda <b>{openTabs}</b> {openTabs, plural, =1 {tab} muu {tabs}} ja kustutada <b>kogu</b> sirvimisajalugu ja küpsised ({cookies} {cookies, plural, =1 {site} muu {sites}})?",
+    "title": "Kas sulgeda <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}} ja kustutada <b>kogu</b> sirvimisajalugu ja küpsised ({cookies} {cookies, plural, =1 {site} other {sites}})?",
     "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Kas sulgeda <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}} ja kustutada <b>kõik</b> küpsised ({cookies} {cookies, plural, =1 {site} muu {sites}})?",
+    "title": "Kas sulgeda <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}} ja kustutada <b>kõik</b> küpsised ({cookies} {cookies, plural, =1 {site} other {sites}})?",
     "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {

--- a/shared/locales/fi/firebutton.json
+++ b/shared/locales/fi/firebutton.json
@@ -10,7 +10,7 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Sulje välilehdet ja tyhjennä tiedot",
+    "title": "Sulje välilehdet ja poista tiedot",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
@@ -19,94 +19,102 @@
   },
   "optionCurrentSite": {
     "title": "Vain nykyinen sivusto",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Viime tunti",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Viimeiset 24 tuntia",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Viimeiset 7 päivää",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Viimeiset 4 viikkoa",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Kaikki",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {yksi tunti} day {24 tuntia} week {yksi viikko} month {4 viikkoa} other {Kaikki}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Sulje <b>{openTabs}</b> välilehti ja tyhjennä <b>{durationDesc}</b> selaushistoriaa ja evästeitä?} other {Sulje <b>{openTabs}</b> välilehteä ja tyhjennä <b>{durationDesc}</b> selaushistoriaa ja evästeitä?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Suljetaanko <b>{openTabs}</b> välilehti ja poistetaanko selaushistoriaa ja evästeitä <b>{durationDesc}</b> ajalta?} other {Suljetaanko <b>{openTabs}</b> välilehteä ja poistetaanko selaushistoriaa ja evästeitä <b>{durationDesc}</b> ajalta?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Sulje <b>{openTabs}</b> välilehti ja tyhjennä <b>{durationDesc}</b> evästeitä?} other {Sulje <b>{openTabs}</b> välilehteä ja tyhjennä <b>{durationDesc}</b> evästeitä?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Suljetaanko <b>{openTabs}</b> välilehti ja poistetaanko evästeet <b>{durationDesc}</b> ajalta?} other {Suljetaanko <b>{openTabs}</b> välilehteä ja poistetaanko evästeet <b>{durationDesc}</b> ajalta?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Tyhjennä <b>{durationDesc}</b> selaushistoriaa ja evästeitä?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Haluatko poistaa selaushistoriaa ja evästeitä <b>{durationDesc}</b> ajalta?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Tyhjennä <b>{durationDesc}</b> evästeitä?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Poistetaanko evästeitä <b>{durationDesc}</b> ajalta?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Sulje <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {välilehteä}} ja tyhjennä <b>kaikki</b> selaushistoria ja evästeet ({cookies} {cookies, plural, =1 {site} other {sivustoa}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Suljetaanko <b>{openTabs}</b> {openTabs, plural, =1 {välilehti} other {välilehteä}} ja poistetaanko <b>kaikki</b> selaushistoria ja evästeet ({cookies} {cookies, plural, =1 {sivusto} other {sivustoa}}) ?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Sulje <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {välilehteä}} ja tyhjennä <b>kaikki</b> evästeet ({cookies} {cookies, plural, =1 {site} other {sivustoa}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Suljetaanko <b>{openTabs}</b> {openTabs, plural, =1 {välilehti} other {välilehteä}} ja poistetaanko <b>kaikki</b> evästeet ({cookies} {cookies, plural, =1 {sivusto} other {sivustoa}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Tyhjennä <b>kaikki</b> ja evästeet ({cookies} sivusto)?} other {Tyhjennä <b>kaikki</b> selaushistoria ja evästeet ({cookies} sivustoa)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Poistetaanko <b>kaikki</b> selaushistoria ja evästeet ({cookies} sivusto)?} other {Poistetaanko <b>kaikki</b> selaushistoria ja evästeet ({cookies} sivustoa)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Poista <b>kaikki</b> evästeet ({cookies} sivusto)?} other {Poista <b>kaikki</b> evästeet ({cookies} sivustoa)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Poistetaanko <b>kaikki</b> evästeet ({cookies} sivusto)?} other {Poistetaanko <b>kaikki</b> evästeet ({cookies} sivustoa)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Sulje <b>{openTabs} {site}</b> välilehti ja tyhjennä <b>kaikki {site}</b> evästeet?} other {Close <b>{openTabs} {site}</b> välilehteä ja tyhjennä <b>kaikki {site}</b> evästeet?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Suljetaanko <b>{openTabs} {site}</b> välilehti ja poistetaanko <b>kaikki {site}</b> evästeet?} other {Suljetaanko <b>{openTabs} {site}</b> välilehteä ja poistetaanko <b>kaikki {site}</b> evästeet?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Sulje <b>{openTabs} {site}</b> välilehti ja tyhjennä <b>kaikki {site}</b> evästeet?} other {Sulje <b>{openTabs} {site}</b> välilehteä ja tyhjennä <b>kaikki {site}</b> evästeet?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Sulje <b>{openTabs} {site}</b> välilehteä ja tyhjennä <b>kaikki {site}</b> evästeet?} other {Suljetaanko <b>{openTabs} {site}</b> välilehteä ja poistetaanko <b>kaikki {site}</b> evästeet?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Tyhjennä <b>kaikki {site}</b> selaushistoria ja evästeet?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Poistetaanko <b>kaikki sivuston {site}</b> selaushistoria ja evästeet?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Tyhjennä <b>kaikki {site}</b> evästeet?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Poista <b>kaikki sivuston {site}</b> evästeet?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} kiinnitetty</b> välilehti ohitetaan.} other {<b>{tabs} kiinnitettyä</b> välilehteä ohitetaan.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Tyhjennä",
-    "note": "Button text to start data clearing."
+    "title": "Poista",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Peruuta",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Tämä palauttaa hakuasetuksesi.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Lue lisää",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Jos haluat tyhjentää myös historian, valitse ajanjakso.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Valitse ajanjakso, jos haluat poistaa myös historian.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/fr/firebutton.json
+++ b/shared/locales/fr/firebutton.json
@@ -10,103 +10,111 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Fermer les onglets et effacer les données",
+    "title": "Fermer les onglets et supprimer les données",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Effacer les données",
+    "title": "Supprimer les données",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Site actuel uniquement",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Dernière heure",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Dernières 24 heures",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "7 derniers jours",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "4 dernières semaines",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Depuis le début",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {une heure} day {24 heures} week {une semaine} month {4 semaines} other {Tous}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Fermer <b>{openTabs}</b> onglet et effacer <b>{durationDesc}</b> d'historique de navigation et de cookies ?} other {Fermer <b>{openTabs}</b> onglets et effacer <b>{durationDesc}</b> d'historique de navigation et de cookies ?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Fermer <b>{openTabs}</b> onglet et supprimer <b>{durationDesc}</b> d'historique de navigation et de cookies ?} other {Fermer <b>{openTabs}</b> onglets et supprimer <b>{durationDesc}</b> d'historique de navigation et de cookies ?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Fermer <b>{openTabs}</b> onglet et effacer <b>{durationDesc}</b> de cookies ?} other {Fermer <b>{openTabs}</b> onglets et effacer <b>{durationDesc}</b> de cookies ?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Fermer <b>{openTabs}</b> onglet et supprimer <b>{durationDesc}</b> de cookies ?} other {Fermer <b>{openTabs}</b> onglets et supprimer <b>{durationDesc}</b> de cookies ?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Effacer <b>{durationDesc}</b> d'historique de navigation et de cookies ?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Supprimer <b>{durationDesc}</b> d'historique de navigation et de cookies ?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Effacer <b>{durationDesc}</b> de cookies ?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Supprimer <b>{durationDesc}</b> de cookies ?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Fermer <b>{openTabs}</b> {openTabs, plural, =1 {onglet} other {onglets}} et effacer <b>l'intégralité</b> de l'historique de navigation et des cookies ({cookies} {cookies, plural, =1 {site} other {sites}}) ?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Fermer <b>{openTabs}</b> {openTabs, plural, =1 {onglet} other {onglets}} et supprimer <b>l'intégralité</b> de l'historique de navigation et des cookies ({cookies} {cookies, plural, =1 {site} other {sites}}) ?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Fermer <b>{openTabs}</b> {openTabs, plural, =1 {onglet} other {onglets}} et effacer <b>l'intégralité</b> des cookies ({cookies} {cookies, plural, =1 {site} other {sites}}) ?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Fermer <b>{openTabs}</b> {openTabs, plural, =1 {onglet} other {onglets}} et supprimer <b>l'intégralité</b> des cookies ({cookies} {cookies, plural, =1 {site} other {sites}}) ?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Effacer <b>l'intégralité</b> de l'historique de navigation et des cookies ({cookies} site) ?} other {Effacer <b>l'intégralité</b> de l'historique de navigation et des cookies ({cookies} sites) ?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Supprimer <b>l'intégralité</b> de l'historique de navigation et des cookies ({cookies} site) ?} other {Supprimer <b>l'intégralité</b> de l'historique de navigation et des cookies ({cookies} sites) ?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Effacer <b>l'intégralité</b> des cookies ({cookies} site) ?} other {Effacer <b>l'intégralité</b> des cookies ({cookies} sites) ?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Supprimer <b>l'intégralité</b> des cookies ({cookies} site) ?} other {Supprimer <b>l'intégralité</b> des cookies ({cookies} sites) ?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Fermer <b>{openTabs} onglet {site}</b> et effacer <b>tous les cookies {site}</b> ?} other {Fermer <b>{openTabs} onglets {site}</b> et effacer <b>tous les cookies {site}</b> ?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Fermer <b>{openTabs} onglet {site}</b> et supprimer <b>tous les cookies {site}</b> ?} other {Fermer <b>{openTabs} onglets {site}</b> et supprimer <b>tous les cookies {site}</b> ?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Fermer <b>{openTabs} onglet {site}</b> et effacer <b>tous les cookies {site}</b> ?} other {Fermer <b>{openTabs} onglets {site}</b> et effacer <b>tous les cookies {site}</b> ?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Fermer <b>{openTabs} onglet {site}</b> et supprimer <b>tous les cookies {site}</b> ?} other {Fermer <b>{openTabs} onglets {site}</b> et supprimer <b>tous les cookies {site}</b> ?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Effacer <b>l'intégralité</b> de l'historique de navigation et des cookies {site} ?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Supprimer <b>l'intégralité</b> de l'historique de navigation et des cookies {site} ?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Effacer <b>l'intégralité</b> des cookies {site} ?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Supprime <b>tous les cookies de {site}</b> ?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} onglet épinglé</b> sera ignoré.} other {<b>{tabs} onglets épinglés</b> seront ignorés.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Effacer",
-    "note": "Button text to start data clearing."
+    "title": "Supprimer",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Annuler",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Cela réinitialisera vos paramètres de recherche.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "En savoir plus",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Pour effacer également l'historique, sélectionnez une période.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Pour supprimer également l'historique, sélectionnez une période.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/hr/firebutton.json
+++ b/shared/locales/hr/firebutton.json
@@ -10,36 +10,36 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Zatvori kartice i obriši podatke",
+    "title": "Zatvori kartice i izbriši podatke",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Obriši podatke",
+    "title": "Izbriši podatke",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Samo aktualna web lokacija",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Posljednjih sat vremena",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Posljednja 24 sata",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Posljednjih 7 dana",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Posljednja 4 tjedna",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Sve vrijeme",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {jedan sat} day {24 sata} week {jedan tjedan} month {4 tjedna} other {Sve}}",
@@ -47,51 +47,51 @@
   },
   "summaryClearTabsHistoryDuration": {
     "title": "{openTabs, plural, one {Zatvoriti <b>{openTabs}</b> karticu i izbrisati <b>{durationDesc}</b> povijesti pregledavanja i kolačića?} few {Zatvoriti <b>{openTabs}</b> kartice i izbrisati <b>{durationDesc}</b> povijesti pregledavanja i kolačića?} many {Zatvoriti <b>{openTabs}</b> kartica i izbrisati <b>{durationDesc}</b> povijesti pregledavanja i kolačića?} other {Zatvoriti <b>{openTabs}</b> kartica i izbrisati <b>{durationDesc}</b> povijesti pregledavanja i kolačića?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Zatvoriti <b>{openTabs}</b> karticu i izbrisati <b>{durationDesc}</b> kolačić?} few {Zatvoriti <b>{openTabs}</b> kartice i izbrisati <b>{durationDesc}</b> kolačića?} many {Zatvoriti <b>{openTabs}</b> kartica i izbrisati <b>{durationDesc}</b> kolačića?} other {Zatvoriti <b>{openTabs}</b> kartica i izbrisati <b>{durationDesc}</b> kolačića?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Zatvoriti <b>{openTabs}</b> karticu i izbrisati <b>{durationDesc}</b> kolačića?} few {Zatvoriti <b>{openTabs}</b> kartice i izbrisati <b>{durationDesc}</b> kolačića?} many {Zatvoriti <b>{openTabs}</b> kartica i izbrisati <b>{durationDesc}</b> kolačića?} other {Zatvoriti <b>{openTabs}</b> kartica i izbrisati <b>{durationDesc}</b> kolačića?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
     "title": "Izbrisati <b>{durationDesc}</b> povijesti pregledavanja i kolačića?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
     "title": "Izbrisati <b>{durationDesc}</b> kolačića?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Zatvoriti <b>{openTabs}</b> {openTabs, plural, =1 {karticu} other {kartice}} i izbrisati <b>cjelokupnu</b> povijest pretraživanja i sve kolačiće ({cookies} {cookies, plural, =1 {web lokacija} other {web lokacije}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Zatvoriti <b>{openTabs}</b> {openTabs, plural, =1 {karticu} other {kartice}}, i izbrisati <b>cjelokupnu</b> povijest pretraživanja i sve kolačiće ({cookies} {cookies, plural, =1 {web lokaciju} other {web lokacije}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
     "title": "Zatvoriti <b>{openTabs}</b> {openTabs, plural, =1 {karticu} other {kartice}} i izbrisati <b>sve</b> kolačiće ({cookies} {cookies, plural, =1 {web lokacija} other {web lokacije}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Izbrisati <b>svu</b> povijest pregledavanja i kolačiće ({cookies} web lokacija)?} few {Izbrisati <b>svu</b> povijest pregledavanja i kolačiće ({cookies} web lokacije)?} many {Izbrisati <b>svu</b> povijest pregledavanja i kolačiće ({cookies} web lokacija)?} other {Izbrisati <b>svu</b> povijest pregledavanja i kolačiće ({cookies} web lokacija)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Izbrisati <b>svu</b> povijest pregledavanja i kolačiće ({cookies} web lokaciju)?} few {Izbrisati <b>svu</b> povijest pregledavanja i kolačiće ({cookies} web lokacije)?} many {Izbrisati <b>svu</b> povijest pregledavanja i kolačiće ({cookies} web lokacija)?} other {Izbrisati <b>svu</b> povijest pregledavanja i kolačiće ({cookies} web lokacija)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Obrisati <b>sve</b> kolačiće ({cookies} web lokacija)?} few {Obrisati <b>sve</b> kolačiće ({cookies} web lokacije)?} many {Obrisati <b>sve</b> kolačiće ({cookies} web lokacija)?} other {Obrisati <b>sve</b> kolačiće ({cookies} web lokacija)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Izbrisati <b>sve</b> kolačiće ({cookies} web lokacija)?} few {Izbrisati <b>sve</b> kolačiće ({cookies} web lokacije)?} many {Izbrisati <b>sve</b> kolačiće ({cookies} web lokacija)?} other {Izbrisati <b>sve</b> kolačiće ({cookies} web lokacija)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Zatvoriti <b>{openTabs} {site}</b> karticu i izbrisati <b>sve kolačiće na {site}</b>?} few {Zatvoriti <b>{openTabs} {site}</b> kartice i izbrisati <b>sve kolačiće na {site}</b>?} many {Zatvoriti <b>{openTabs} {site}</b> kartica i izbrisati <b>sve kolačiće na {site}</b>?} other {Zatvoriti <b>{openTabs} {site}</b> kartica i izbrisati <b>sve kolačiće na {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Zatvoriti <b>{openTabs} {site}</b> karticu i izbrisati <b> {site}</b> kolačić?} few {Zatvoriti <b>{openTabs} {site}</b> kartice i izbrisati <b>sva {site}</b> kolačića?} many {Zatvoriti <b>{openTabs} {site}</b> kartica i izbrisati <b>svih {site}</b> kolačića?} other {Zatvoriti <b>{openTabs} {site}</b> kartica i izbrisati <b>svih {site}</b> kolačića?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Zatvoriti <b>{openTabs} {site}</b> karticu i izbrisati <b>sve kolačiće na {site}</b>?} few {Zatvoriti <b>{openTabs} {site}</b> kartice i izbrisati <b>sve kolačiće na {site}</b>?} many {Zatvoriti <b>{openTabs} {site}</b> kartica i izbrisati <b>sve kolačiće na {site}</b>?} other {Zatvoriti <b>{openTabs} {site}</b> kartica i izbrisati <b>sve kolačiće na {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Zatvoriti <b>{openTabs} {site}</b> karticu i izbrisati <b> {site}</b> kolačić?} few {Zatvoriti <b>{openTabs} {site}</b> kartice i izbrisati <b>sva {site}</b> kolačića?} many {Zatvoriti <b>{openTabs} {site}</b> kartica i izbrisati <b>svih {site}</b> kolačića?} other {Zatvoriti <b>{openTabs} {site}</b> kartica i izbrisati <b>svih {site}</b> kolačića?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Izbrisati <b>svu povijest pregledavanja i kolačiće na {site}</b> ?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Izbrisati <b>svu povijest pregledavanja i kolačiće na adresi {site}</b> ?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Izbrisati <b>sve kolačiće na {site}</b> ?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Izbrisati <b>sve kolačiće na adresi {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} prikvačena</b> kartica bit će zanemarena.} few {<b>{tabs} prikvačene</b> kartice bit će zanemareno.} many {<b>{tabs} prikvačenih</b> kartica bit će zanemareno.} other {<b>{tabs} prikvačenih</b> kartica bit će zanemareno.}}",
@@ -99,14 +99,22 @@
   },
   "clearData": {
     "title": "Izbriši",
-    "note": "Button text to start data clearing."
+    "note": "Button text to start data deletion."
   },
   "cancel": {
-    "title": "Odustani",
+    "title": "Otkaži",
     "note": "Button text to exit the fire button modal."
+  },
+  "clearingCookiesWarning": {
+    "title": "Ovim ćeš resetirati postavke pretraživanja.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Saznajte više",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
   },
   "historyAndDownloadsNotAffected": {
     "title": "Za brisanje povijesti odaberi vremensko razdoblje.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/hu/firebutton.json
+++ b/shared/locales/hu/firebutton.json
@@ -10,7 +10,7 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Lapok bezárása és adattörlés",
+    "title": "Lapok bezárása és adatok törlése",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
@@ -19,79 +19,79 @@
   },
   "optionCurrentSite": {
     "title": "Csak a jelenlegi webhely",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Előző 1 óra",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Előző 24 óra",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Előző 7 nap",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Előző 4 hét",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Minden időpont",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {egy óra} day {24 óra} week {egy hét} month {négy hét} other {Összes}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Bezárod a megnyitott <b>{openTabs}</b> lapot, és törlöd az előző <b>{durationDesc}</b> böngészési előzményeit és sütijeit?} other {Bezárod a megnyitott <b>{openTabs}</b> lapot, és törlöd az előző <b>{durationDesc}</b> böngészési előzményeket és sütijeit?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Bezársz <b>{openTabs}</b> lapot, és törlöd az előző <b>{durationDesc}</b> böngészési előzményeit és sütijeit?} other {Bezársz <b>{openTabs}</b> lapot, és törlöd az előző <b>{durationDesc}</b> böngészési előzményeit és sütijeit?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Bezárod a megnyitott <b>{openTabs}</b> lapot és törlöd az előző <b>{durationDesc}</b> sütijeit?} other {Bezárod a megnyitott <b>{openTabs}</b> lapot és törlöd az előző <b>{durationDesc}</b> sütijeit?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Bezársz <b>{openTabs}</b> lapot, és törlöd az előző <b>{durationDesc}</b> sütijeit?} other {Bezársz <b>{openTabs}</b> lapot, és törlöd az előző <b>{durationDesc}</b> sütijeit?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
     "title": "Törlöd az előző <b>{durationDesc}</b> böngészési előzményeit és sütijeit?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
     "title": "Törlöd az előző <b>{durationDesc}</b> sütijeit?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Bezárod a megnyitott <b>{openTabs}</b> {openTabs, plural, =1 {lapot} other {lapot}}, és törölsz <b>minden</b> böngészési előzményt és sütit ({cookies} {cookies, plural, =1 {webhelyet} other {webhelyet}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Bezársz <b>{openTabs}</b> {openTabs, plural, =1 {lapot} other {lapot}}, és törlöd az <b>összes</b> böngészési előzményt és sütit ({cookies} {cookies, plural, =1 {webhelyről} other {webhely}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Bezárod a megnyitott <b>{openTabs}</b> {openTabs, plural, =1 {lapot} other {lapot}}, és törölsz <b>minden</b> sütit ({cookies} {cookies, plural, =1 {webhelyet} other {webhelyet}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Bezársz <b>{openTabs}</b> {openTabs, plural, =1 {lapot} other {lapot}}, és törlöd az <b>összes</b> sütit ({cookies} {cookies, plural, =1 {webhely} other {webhelyről}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Törölsz <b>minden</b> böngészési előzményt és sütit ({cookies} webhelyet)?} other {Törölsz <b>minden</b> böngészési előzményt és sütit ({cookies} webhelyet)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Törlöd az <b>összes</b> böngészési előzményt és sütit ({cookies} webhely)?} other {Törlöd az <b>összes</b> böngészési előzményt és sütit ({cookies} webhely)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Törölsz <b>minden</b> sütit ({cookies} webhelyet)?} other {Törölsz <b>minden</b> sütit ({cookies} webhelyet)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Törlöd az <b>összes</b> sütit ({cookies} webhely)?} other {Törlöd az <b>összes</b> sütit ({cookies} webhely)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Bezárod a megnyitott <b>{openTabs} {site}</b> lapot, és törölsz <b>minden {site}</b> sütit?} other {Bezárod a megnyitott <b>{openTabs} {site}</b> lapot, és törölsz <b>minden {site}</b> sütit?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Bezársz <b>{openTabs} {site}</b> lapot, és törlöd az <b>összes {site}</b> sütit?} other {Bezársz <b>{openTabs} {site}</b> lapot, és törlöd az <b>összes {site}</b> sütit?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Bezárod a megnyitott <b>{openTabs} {site}</b> lapot, és törölsz <b>minden {site}</b> sütit?} other {Bezárod a megnyitott <b>{openTabs} {site}</b> lapot, és törölsz <b>minden {site}</b> sütit?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Bezársz <b>{openTabs} {site}</b> lapot, és törlöd az <b>összes {site}</b> sütit?} other {Bezársz <b>{openTabs} {site}</b> lapot, és törlöd az <b>összes {site}</b> sütit?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Törölsz <b>minden {site}</b> böngészési előzményt és sütit?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Törlöd az <b>összes {site}</b> böngészési előzményt és sütit?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Törölsz <b>minden {site}</b> sütit?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Törlöd az <b>összes {site}</b> sütit?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} rögzített</b> lap érintetlen marad.} other {<b>{tabs} rögzített</b> lap érintetlen marad.}}",
@@ -99,14 +99,22 @@
   },
   "clearData": {
     "title": "Törlés",
-    "note": "Button text to start data clearing."
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Mégsem",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Ezzel visszaállnak a keresési beállításaid.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "További részletek",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Ha az előzményeket is törölni szeretnéd, válassz egy időtartamot.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Ha az előzményeket is törölni szeretnéd, válassz ki egy időszakot.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/it/firebutton.json
+++ b/shared/locales/it/firebutton.json
@@ -10,7 +10,7 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Chiudi le schede e cancella i dati",
+    "title": "Chiudi le schede ed elimina i dati",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
@@ -19,94 +19,102 @@
   },
   "optionCurrentSite": {
     "title": "Solo sito corrente",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Ultima ora",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Ultime 24 ore",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Ultimi 7 giorni",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Ultime 4 settimane",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Sempre",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {un'ora} day {24 ore} week {una settimana} month {4 settimane} other {Tutto}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Chiudere <b>{openTabs}</b> scheda ed eliminare <b>{durationDesc}</b> di cronologia di navigazione e di cookie?} other {Chiudere <b>{openTabs}</b> schede ed eliminare <b>{durationDesc}</b> di cronologia di navigazione e di cookie?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Chiudere <b>{openTabs}</b> scheda ed eliminare <b>{durationDesc}</b> di cronologia di navigazione e cookie?} other {Chiudere <b>{openTabs}</b> schede ed eliminare <b>{durationDesc}</b> di cronologia di navigazione e cookie?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
     "title": "{openTabs, plural, one {Chiudere <b>{openTabs}</b> scheda ed eliminare <b>{durationDesc}</b> di cookie?} other {Chiudere <b>{openTabs}</b> schede ed eliminare <b>{durationDesc}</b> di cookie?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
     "title": "Eliminare <b>{durationDesc}</b> di cronologia di navigazione e di cookie?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
     "title": "Eliminare <b>{durationDesc}</b> di cookie?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Chiudere <b>{openTabs}</b> {openTabs, plural, =1 {scheda} other {schede}} ed eliminare <b>tutti</b> i dati della cronologia di navigazione e dei cookie ({cookies} {cookies, plural, =1 {sito} other {siti}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Chiudere <b>{openTabs}</b> {openTabs, plural, =1 {scheda} other {schede}} ed eliminare <b>tutti</b> i dati della cronologia di navigazione e dei cookie ({cookie} {cookie, plural, =1 {sito} other {siti}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Chiudere <b>{openTabs}</b> {openTabs, plural, =1 {scheda} other {schede}} ed eliminare <b>tutti</b> i cookie ({cookies} {cookies, plural, =1 {sito} other {siti}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Chiudere <b>{openTabs}</b> {openTabs, plural, =1 {scheda} other {schede}} ed eliminare <b>tutti</b> i cookie ({cookie} {cookies, plural, =1 {sito} other {siti}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
     "title": "{cookies, plural, one {Eliminare <b>tutta</b> la cronologia di navigazione e i cookie ({cookies} sito)?} other {Eliminare <b>tutta</b> la cronologia di navigazione e i cookie ({cookies} siti)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Eliminare <b>tutti</b> i cookie ({cookies} sito)?} other {Eliminare <b>tutti</b> i cookie ({cookies} siti)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Eliminare <b>tutti</b> i cookie ({cookies} sito)?} other {Eliminare <b>tutti i</b> cookie ({cookies} siti)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Chiudere <b>{openTabs} {site}</b> scheda ed eliminare <b>tutti i cookie {site}</b>?} other {Chiudere <b>{openTabs} {site}</b> schede ed eliminare <b>tutti i cookie {site}</b> ?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Chiudere <b>{openTabs} {site}</b> scheda ed eliminare <b>tutti i cookie di {site}</b>?} other {Chiudere <b>{openTabs} {site}</b> schede ed eliminare <b>tutti i cookie di {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Chiudere la scheda <b>{openTabs} {site}</b> ed eliminare <b>tutti i cookie {site}</b>?} other {Chiudere le schede <b>{openTabs} {site}</b> ed eliminare <b>tutti i cookie {site}</b> ?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Chiudere <b>{openTabs} {site}</b> scheda ed eliminare <b>tutti i cookie di {site}</b>?} other {Chiudere <b>{openTabs} {site}</b> schede ed eliminare <b>tutti i cookie di {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
     "title": "Eliminare <b>tutta {site}</b> la cronologia di navigazione e i cookie?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Eliminare <b>tutti i cookie di {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Eliminare <b>tutti {site}</b> i cookie?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} scheda bloccata</b> sarà ignorata.} other {<b>{tabs} schede bloccate</b> saranno ignorate.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Cancella",
-    "note": "Button text to start data clearing."
+    "title": "Elimina",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Annulla",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Questa operazione ripristinerà le impostazioni di ricerca.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Ulteriori informazioni",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Per cancellare anche la cronologia, seleziona un periodo di tempo.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Per eliminare anche la cronologia, seleziona un periodo di tempo.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/it/firebutton.json
+++ b/shared/locales/it/firebutton.json
@@ -62,11 +62,11 @@
     "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Chiudere <b>{openTabs}</b> {openTabs, plural, =1 {scheda} other {schede}} ed eliminare <b>tutti</b> i dati della cronologia di navigazione e dei cookie ({cookie} {cookie, plural, =1 {sito} other {siti}})?",
+    "title": "Chiudere <b>{openTabs}</b> {openTabs, plural, =1 {scheda} other {schede}} ed eliminare <b>tutti</b> i dati della cronologia di navigazione e dei cookie ({cookies} {cookies, plural, =1 {sito} other {siti}})?",
     "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Chiudere <b>{openTabs}</b> {openTabs, plural, =1 {scheda} other {schede}} ed eliminare <b>tutti</b> i cookie ({cookie} {cookies, plural, =1 {sito} other {siti}})?",
+    "title": "Chiudere <b>{openTabs}</b> {openTabs, plural, =1 {scheda} other {schede}} ed eliminare <b>tutti</b> i cookie ({cookies} {cookies, plural, =1 {sito} other {siti}})?",
     "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {

--- a/shared/locales/lt/firebutton.json
+++ b/shared/locales/lt/firebutton.json
@@ -10,103 +10,111 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Uždaryti skirtukus ir valyti duomenis",
+    "title": "Uždaryti korteles ir ištrinti duomenis",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Valyti duomenis",
+    "title": "Ištrinti duomenis",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Tik dabartinė svetainė",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Paskutinė valanda",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Paskutinės 24 valandos",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Paskutinės 7 dienos",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Paskutinės 4 savaitės",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Viso laiko",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {viena valanda} day {24 valandos} week {viena savaitė} month {4 savaitės} other {Visi}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Uždaryti <b>{openTabs}</b> skirtuką ir išvalyti <b>{durationDesc}</b> naršymo istoriją ir slapukus?} few {Uždaryti <b>{openTabs}</b> skirtukus ir išvalyti <b>{durationDesc}</b> naršymo istoriją ir slapukus?} many {Uždaryti <b>{openTabs}</b> skirtuko ir išvalyti <b>{durationDesc}</b> naršymo istoriją ir slapukus?} other {Uždaryti <b>{openTabs}</b> skirtukų ir išvalyti <b>{durationDesc}</b> naršymo istoriją ir slapukus?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Uždaryti <b>{openTabs}</b> kortelę ir ištrinti <b>{durationDesc}</b> naršymo istorijos bei slapukų?} few {Uždaryti <b>{openTabs}</b> korteles ir ištrinti <b>{durationDesc}</b> naršymo istorijos bei slapukų?} many {Uždaryti <b>{openTabs}</b> kortelės ir ištrinti <b>{durationDesc}</b> naršymo istorijos bei slapukų?} other {Uždaryti <b>{openTabs}</b> kortelių ir ištrinti <b>{durationDesc}</b> naršymo istorijos bei slapukų?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Uždaryti <b>{openTabs}</b> skirtuką ir išvalyti <b>{durationDesc}</b> slapukus?} few {Uždaryti <b>{openTabs}</b> skirtukus ir išvalyti <b>{durationDesc}</b> slapukus?} many {Uždaryti <b>{openTabs}</b> skirtuko ir išvalyti <b>{durationDesc}</b> slapukus?} other {Uždaryti <b>{openTabs}</b> skirtukų ir išvalyti <b>{durationDesc}</b> slapukus?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Uždaryti <b>{openTabs}</b> kortelę ir ištrinti <b>{durationDesc}</b> slapukų?} few {Uždaryti <b>{openTabs}</b> korteles ir ištrinti <b>{durationDesc}</b> slapukų?} many {Uždaryti <b>{openTabs}</b> kortelės ir ištrinti <b>{durationDesc}</b> slapukų?} other {Uždaryti <b>{openTabs}</b> kortelių ir ištrinti <b>{durationDesc}</b> slapukų?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Išvalyti <b>{durationDesc}</b> naršymo istoriją ir slapukus?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Ištrinti <b>{durationDesc}</b> naršymo istorijos ir slapukų?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Išvalyti <b>{durationDesc}</b> slapukus?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Ištrinti <b>{durationDesc}</b> slapukų?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Uždaryti <b>{openTabs}</b> {openTabs, plural, =1 {skirtuką} few {skirtukus} other {skirtukų}}, ir išvalyti <b>visą</b> naršymo istoriją ir slapukus ({cookies} {cookies, plural, =1 {svetainėje} few {svetainėse} other {svetainių}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Uždaryti <b>{openTabs}</b> {openTabs, plural, =1 {kortelę} few {korteles} other {kortelių}} ir ištrinti <b>visą</b> naršymo istoriją bei slapukus ({cookies} {cookies, plural, =1 {svetainėje} few {svetainėse} other {svetainių}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Uždaryti <b>{openTabs}</b> {openTabs, plural, =1 {skirtuką} few {skirtukus} other {skirtukų}}, ir išvalyti <b>visus</b> slapukus ({cookies} {cookies, plural, =1 {svetainėje} few {svetainėse} other {svetainių}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Uždaryti <b>{openTabs}</b> {openTabs, plural, =1 {kortelę} few {korteles} other {kortelių}} ir ištrinti <b>visus</b> slapukus ({cookies} {cookies, plural, =1 {svetainėje} few {svetainėse} other {svetainių}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Išvalyti <b>visą</b> naršymo istoriją ir slapukus ({cookies} svetainėje)?} few {Išvalyti <b>visą</b> naršymo istoriją ir slapukus ({cookies} svetainėse)?} many {Išvalyti <b>visą</b> naršymo istoriją ir slapukus ({cookies} svetainės)?} other {Išvalyti <b>visą</b> naršymo istoriją ir slapukus ({cookies} svetainių)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Ištrinti <b>visą</b> naršymo istoriją ir slapukus ({cookies} svetainėje)?} few {Ištrinti <b>visą</b> naršymo istoriją ir slapukus ({cookies} svetainėse)?} many {Ištrinti <b>visą</b> naršymo istoriją ir slapukus ({cookies} svetainės)?} other {Ištrinti <b>visą</b> naršymo istoriją ir slapukus ({cookies} svetainių)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Išvalyti <b>visus</b> slapukus ({cookies} svetainėje)?} few {Išvalyti <b>visus</b> slapukus ({cookies} svetainėse)?} many {Išvalyti <b>visus</b> slapukus ({cookies} svetainės)?} other {Išvalyti <b>visus</b> slapukus ({cookies} svetainių)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Ištrinti <b>visus</b> slapukus ({cookies} svetainėje)?} few {Ištrinti <b>visus</b> slapukus ({cookies} svetainėse)?} many {Ištrinti <b>visus</b> slapukus ({cookies} svetainės)?} other {Ištrinti <b>visus</b> slapukus ({cookies} svetainių)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Uždaryti <b>{openTabs} {site}</b> skirtuką ir išvalyti <b>visus {site}</b> slapukus?} few {Uždaryti <b>{openTabs} {site}</b> skirtukus ir išvalyti <b>visus {site}</b> slapukus?} many {Uždaryti <b>{openTabs} {site}</b> skirtuko ir išvalyti <b>visus {site}</b> slapukus?} other {Uždaryti <b>{openTabs} {site}</b> skirtukų ir išvalyti <b>visus {site}</b> slapukus?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Uždaryti <b>{openTabs} {site}</b> kortelę ir ištrinti <b>visus {site}</b> slapukus?} few {Uždaryti <b>{openTabs} {site}</b> korteles ir ištrinti <b>visus {site}</b> slapukus?} many {Uždaryti <b>{openTabs} {site}</b> kortelės ir ištrinti <b>visus {site}</b> slapukus?} other {Uždaryti <b>{openTabs} {site}</b> kortelių ir ištrinti <b>visus {site}</b> slapukus?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Uždarykite <b>{openTabs} {site}</b> skirtukus ir išvalykite <b>visus {site}</b> slapukus?} few {Uždaryti <b>{openTabs} {site}</b> skirtukus ir išvalyti <b>visus {site}</b> slapukus?} many {Uždaryti <b>{openTabs} {site}</b> skirtuko ir išvalyti <b>visus {site}</b> slapukus?} other {Uždaryti <b>{openTabs} {site}</b> skirtukų ir išvalyti <b>visus {site}</b> slapukus?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Uždaryti <b>{openTabs} {site}</b> kortelę ir ištrinti <b>visus {site}</b> slapukus?} few {Uždaryti <b>{openTabs} {site}</b> korteles ir ištrinti <b>visus {site}</b> slapukus?} many {Uždaryti <b>{openTabs} {site}</b> kortelės ir ištrinti <b>visus {site}</b> slapukus?} other {Uždaryti <b>{openTabs} {site}</b> kortelių ir ištrinti <b>visus {site}</b> slapukus?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Išvalyti <b>visą {site}</b> naršymo istoriją ir slapukus?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Ištrinti <b>visą {site}</b> naršymo istoriją ir slapukus?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Išvalyti <b>visus {site}</b> slapukus?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Ištrinti <b>visus {site}</b> slapukus?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} prisegtas</b> skirtukas bus ignoruojamas.} few {<b>{tabs} prisegti</b> skirtukai bus ignoruojami.} many {<b>{tabs} prisegto</b> skirtuko bus ignoruojama.} other {<b>{tabs} prisegtų</b> skirtukų bus ignoruojama.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Valyti",
-    "note": "Button text to start data clearing."
+    "title": "Trinti",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Atšaukti",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Paieškos nuostatos bus atkurtos.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Sužinoti daugiau",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Norėdami išvalyti istoriją, pasirinkite laikotarpį.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Jei nori ištrinti ir istoriją, pasirink laikotarpį.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/lv/firebutton.json
+++ b/shared/locales/lv/firebutton.json
@@ -10,103 +10,111 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Aizvērt cilnes un notīrīt datus",
+    "title": "Aizvērt cilnes un dzēst datus",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Notīrīt datus",
+    "title": "Dzēst datus",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Tikai pašreizējā vietne",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Pēdējā stunda",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Pēdējās 24 stundas",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Pēdējās 7 dienas",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Pēdējās 4 nedēļas",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Visu laiku",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {viena stunda} day {24 stundas} week {viena nedēļa} month {4 nedēļas} other {Viss}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, zero {Aizvērt <b>{openTabs}</b> cilnes un notīrīt pārlūkošanas vēsturi un sīkfailus (<b>{durationDesc}</b>)?} one {Aizvērt <b>{openTabs}</b> cilni un notīrīt pārlūkošanas vēsturi un sīkfailus (<b>{durationDesc}</b>)?} other {Aizvērt <b>{openTabs}</b> cilnes un notīrīt pārlūkošanas vēsturi un sīkfailus (<b>{durationDesc}</b>)?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, zero {Vai aizvērt <b>{openTabs}</b> cilnes un dzēst <b>{durationDesc}</b> pārlūkošanas vēsturi un sīkfailus?} one {Vai aizvērt <b>{openTabs}</b> cilni un dzēst <b>{durationDesc}</b> pārlūkošanas vēsturi un sīkfailus?} other {Vai aizvērt <b>{openTabs}</b> cilnes un dzēst <b>{durationDesc}</b> pārlūkošanas vēsturi un sīkfailus?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, zero {Aizvērt <b>{openTabs}</b> cilnes un notīrīt sīkfailus (<b>{durationDesc}</b>)?} one {Aizvērt <b>{openTabs}</b> cilni un notīrīt sīkfailus (<b>{durationDesc}</b>)?} other {Aizvērt <b>{openTabs}</b> cilnes un notīrīt sīkfailus (<b>{durationDesc}</b>)?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, zero {Vai aizvērt <b>{openTabs}</b> cilnes un dzēst <b>{durationDesc}</b> sīkfailus?} one {Vai aizvērt <b>{openTabs}</b> cilni un dzēst <b>{durationDesc}</b> sīkfailus?} other {Vai aizvērt <b>{openTabs}</b> cilnes un dzēst <b>{durationDesc}</b> sīkfailus?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Notīrīt pārlūkošanas vēsturi un sīkfailus (<b>{durationDesc}</b>)?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Vai dzēst <b>{durationDesc}</b> pārlūkōšanas vēstures un sīkfailu?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Notīrīt sīkfailus (<b>{durationDesc}</b>)?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Vai dzēst <b>{durationDesc}</b> sīkfailus?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Aizvērt <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}} un notīrīt <b>visu</b> pārlūkošanas vēsturi un sīkfailus ({cookies} {cookies, plural, =1 {site} other {sites}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Aizvērt <b>{openTabs}</b> {openTabs, plural, =1 {cilne} other {cilnes}} un izdzēst <b>visu</b> pārlūkošanas vēsturi un sīkfailus ({cookies} {cookies, plural, =1 {vietne} other {vietnes}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Aizvērt <b>{openTabs}</b>{openTabs, plural, =1 {tab} other {tabs}} un notīrīt <b>visus</b> sīkfailus ({cookies} {cookies, plural, =1 {site} other {sites}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Aizvērt <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}} un dzēst <b>visus</b> sīkfailus ({cookies} {cookies, plural, =1 {site} other {sites}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, zero {Notīrīt <b>visu</b> pārlūkošanas vēsturi un sīkfailus ({cookies} vietnes)?} one {Notīrīt <b>visu</b> pārlūkošanas vēsturi un sīkfailus ({cookies} vietne)?} other {Notīrīt <b>visu</b> pārlūkošanas vēsturi un sīkfailus ({cookies} vietnes)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, zero {Vai dzēst <b>visu</b> pārlūkošanas vēsturi un sīkfailus ({cookies} vietnes)?} one {Vai dzēst <b>visu</b> pārlūkošanas vēsturi un sīkfailus ({cookies} vietni)?} other {Vai dzēst <b>visu</b> pārlūkošanas vēsturi un sīkfailus ({cookies} vietnes)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, zero {Notīrīt <b>visus</b> sīkfailus ({cookies} vietnes)?} one {Notīrīt <b>visus</b> sīkfailus ({cookies} vietne)?} other {Notīrīt <b>visus</b> sīkfailus ({cookies} vietnes)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, zero {Vai dzēst <b>visus</b> sīkfailus ({cookies} vietnes)?} one {Vai dzēst <b>visus</b> sīkfailus ({cookies} vietni)?} other {Vai dzēst <b>visus</b> sīkfailus ({cookies} vietnes)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, zero {Aizvērt <b>{openTabs} {site}</b> cilnes un notīrīt <b>visus {site}</b> sīkfailus?} one {Aizvērt <b>{openTabs} {site}</b> cilni un notīrīt <b>visus {site}</b> sīkfailus?} other {Aizvērt <b>{openTabs} {site}</b> cilnes un notīrīt <b>visus {site}</b> sīkfailus?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, zero {Vai aizvērt <b>{openTabs} {site}</b> cilnes un dzēst <b>visus {site}</b> sīkfailus?} one {Vai aizvērt <b>{openTabs} {site}</b> cilni un dzēst <b>visu {site}</b> sīkfailu?} other {Vai aizvērt <b>{openTabs} {site}</b> cilnes un dzēst <b>visus {site}</b> sīkfailus?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, zero {Aizvērt <b>{openTabs} {site}</b> cilnes un notīrīt <b>visus {site}</b> sīkfailus?} one {Aizvērt <b>{openTabs} {site}</b> cilni un notīrīt <b>visus {site}</b> sīkfailus?} other {Aizvērt <b>{openTabs} {site}</b> cilnes un notīrīt <b>visus {site}</b> sīkfailus?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, zero {Vai aizvērt <b>{openTabs} {site}</b> cilnes un dzēst <b>visus {site}</b> sīkfailus?} one {Vai aizvērt <b>{openTabs} {site}</b> cilni un dzēst <b>visu {site}</b> sīkfailu?} other {Vai aizvērt <b>{openTabs} {site}</b> cilnes un dzēst <b>visus {site}</b> sīkfailus?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Notīrīt <b>visu {site}</b> pārlūkošanas vēsturi un sīkfailus?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Vai dzēst <b>visu {site}</b> pārlūkošanas vēsturi un sīkfailus?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Notīrīt <b>visus {site}</b> sīkfailus?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Vai dzēst <b>visus {site}</b> sīkfailus?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, zero {<b>{tabs} piespraustās</b> cilnes tiks ignorētas.} one {<b>{tabs} piespraustā</b> cilne tiks ignorēta.} other {<b>{tabs} piespraustās</b> cilnes tiks ignorētas.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Notīrīt",
-    "note": "Button text to start data clearing."
+    "title": "Dzēst",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Atcelt",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Tas atiestatīs tavus meklēšanas iestatījumus.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Uzzināt vairāk",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Lai notīrītu arī vēsturi, atlasi laika periodu.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Lai dzēstu arī vēsturi, atlasi laika periodu.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/nb/firebutton.json
+++ b/shared/locales/nb/firebutton.json
@@ -10,7 +10,7 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Lukk faner og slett data",
+    "title": "Lukk faner og fjern data",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
@@ -19,27 +19,27 @@
   },
   "optionCurrentSite": {
     "title": "Bare nåværende nettsted",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Den siste timen",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "De siste 24 timene",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "De siste 7 dagene",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "De siste 4 ukene",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "All tid",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {én time} day {24 timer} week {én uke} month {4 uker} other {Alle}}",
@@ -47,66 +47,74 @@
   },
   "summaryClearTabsHistoryDuration": {
     "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs}</b> fane og fjerne <b>{durationDesc}</b> med nettleserhistorikk og informasjonskapsler?} other {Vil du lukke <b>{openTabs}</b> faner og fjerne <b>{durationDesc}</b> med nettleserhistorikk og informasjonskapsler?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
     "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs}</b> fane og fjerne <b>{durationDesc}</b> med informasjonskapsler?} other {Vil du lukke <b>{openTabs}</b> faner og fjerne <b>{durationDesc}</b> med informasjonskapsler?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
     "title": "Vil du fjerne <b>{durationDesc}</b> med nettleserhistorikk og informasjonskapsler?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
     "title": "Vil du fjerne <b>{durationDesc}</b> med informasjonskapsler?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
     "title": "Vil du lukke <b>{openTabs}</b> {openTabs, plural, =1 {fane} other {faner}} og fjerne <b>all</b> nettleserhistorikk og alle informasjonskapsler ({cookies} {cookies, plural, =1 {nettsted} other {nettsteder}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
     "title": "Vil du lukke <b>{openTabs}</b> {openTabs, plural, =1 {fane} other {faner}}, og fjerne <b>alle</b> informasjonskapsler ({cookies} {cookies, plural, =1 {nettsted} other {nettsteder}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
     "title": "{cookies, plural, one {Vil du fjerne <b>all</b> nettleserhistorikk og alle informasjonskapsler ({cookies} nettsted)?} other {Vil du fjerne <b>all</b> nettleserhistorikk og alle informasjonskapsler ({cookies} nettsteder)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Vil du slette <b>alle</b> informasjonskapsler ({cookies} nettsted)?} other {Vil du slette <b>alle</b> informasjonskapsler ({cookies} nettsteder)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Vil du fjerne <b>alle</b> informasjonskapsler ({cookies} nettsted)?} other {Vil du fjerne <b>alle</b> informasjonskapsler ({cookies} nettsteder)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs} fane for {site}</b>og slette <b>alle informasjonskapsler for {site}</b>?} other {Vil du lukke <b>{openTabs} faner for {site}</b> og slette <b>alle informasjonskapsler for {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs} {site}</b>-fane og fjerne <b>alle informasjonskapsler for {site}</b>?} other {Vil du lukke <b>{openTabs} {site}</b>-faner og fjerne <b>alle informasjonskapsler for {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs} {site}</b>-fane og slette <b>alle informasjonskapsler for {site}</b>?} other {Vil du lukke <b>{openTabs} {site}</b>-faner og slette <b>alle informasjonskapsler for {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Vil du lukke <b>{openTabs} {site}</b>-fane og fjerne <b>alle informasjonskapsler for {site}</b>?} other {Vil du lukke <b>{openTabs} {site}</b>-faner og fjerne <b>alle informasjonskapsler for {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Vil du slette <b>all nettleserhistorikk og alle informasjonskapsler for {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Vil du fjerne <b>all nettleserhistorikk og alle informasjonskapsler fra {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Vil du slette <b>alle informasjonskapsler for {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Vil du fjerne <b>alle informasjonskapsler for {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} festet</b> fane blir ignorert.} other {<b>{tabs} festede</b> faner blir ignorert.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Klarvær",
-    "note": "Button text to start data clearing."
+    "title": "Slett",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Avbryt",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Dette fører til at søkeinnstillingene dine tilbakestilles.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Finn ut mer",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Hvis du også vil tømme historikken, må du velge en tidsperiode.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Hvis du også vil slette historikken, må du velge en tidsperiode.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/nl/firebutton.json
+++ b/shared/locales/nl/firebutton.json
@@ -10,103 +10,111 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Tabbladen sluiten en gegevens wissen",
+    "title": "Tabbladen sluiten en gegevens verwijderen",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Gegevens wissen",
+    "title": "Gegevens verwijderen",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Alleen huidige site",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Afgelopen uur",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Afgelopen 24 uur",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Afgelopen 7 dagen",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Afgelopen 4 weken",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Altijd",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {een uur} day {24 uur} week {een week} month {4 weken} other {Alle}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {<b>{openTabs}</b> tabblad sluiten en je browsegeschiedenis en cookies van <b>{durationDesc}</b> wissen?} other {<b>{openTabs}</b> tabbladen sluiten en je browsegeschiedenis en cookies van <b>{durationDesc}</b> wissen?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {<b>{openTabs}</b> tabblad sluiten en <b>{durationDesc}</b> van de browsegeschiedenis en cookies verwijderen?} other {<b>{openTabs}</b> tabbladen sluiten en <b>{durationDesc}</b> van de browsegeschiedenis en cookies verwijderen?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {<b>{openTabs}</b> tabblad sluiten en cookies van <b>{durationDesc}</b> wissen?} other {<b>{openTabs}</b> tabbladen sluiten en cookies van <b>{durationDesc}</b> wissen?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Sluit <b>{openTabs}</b> tabblad en verwijder <b>{durationDesc}</b> cookies?} other {Sluit <b>{openTabs}</b> tabbladen en verwijder <b>{durationDesc}</b> cookies?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Browsegeschiedenis en cookies van <b>{durationDesc}</b> wissen?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Verwijder <b>{durationDesc}</b> van de browsegeschiedenis en cookies?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Cookies van <b>{durationDesc}</b> wissen?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Verwijder <b>{durationDesc}</b> cookies?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
     "title": "<b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}} sluiten en <b>alle</b> browsegeschiedenis en cookies ({cookies} {cookies, plural, =1 {site} other {sites}}) wissen?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
     "title": "<b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}} sluiten en <b>alle</b> cookies ({cookies} {cookies, plural, =1 {site} other {sites}}) wissen?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {<b>Alle</b> browsegeschiedenis en cookies wissen ({cookies} site)?} other {Alle <b>browsegeschiedenis</b> en cookies wissen ({cookies} sites)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Verwijder <b>alle</b> browsegeschiedenis en cookies ({cookies} site)?} other {Verwijder <b>alle</b> browsegeschiedenis en cookies ({cookies} sites)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {<b>Alle</b> cookies ({cookies} site) wissen?} other {<b>Alle</b> cookies ({cookies} sites) wissen?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Verwijder <b>alle</b> cookies ({cookies} site)?} other {Verwijder <b>alle</b> cookies ({cookies} sites)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {<b>{openTabs} {site}</b> tabblad sluiten en <b>alle</b> cookies van {site} wissen?} other {<b>{openTabs} {site}</b> tabbladen sluiten en <b>alle</b> cookies van {site} wissen?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Sluit <b>{openTabs} {site}</b> tabblad en <b>verwijder alle {site}</b> cookies?} other {Sluit <b>{openTabs} {site}</b> tabbladen en <b>verwijder alle {site}</b> cookies?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {<b>{openTabs} {site}</b> tabblad sluiten en <b>alle</b> cookies van {site} wissen?} other {<b>{openTabs} {site}</b> tabbladen sluiten en <b>alle</b> cookies van {site} wissen?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Sluit <b>{openTabs} {site}</b> tabblad en verwijder <b>alle {site}</b> cookies?} other {Sluit <b>{openTabs} {site}</b> tabbladen en <b>verwijder alle {site}</b> cookies?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "<b>Alle</b> browsegeschiedenis en cookies van {site} wissen?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Alle <b> {site}</b> browsegeschiedenis en cookies verwijderen?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "<b>Alle</b> cookies van {site} wissen?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Verwijder <b>alle {site}</b> cookies?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} vastgemaakt</b> tabblad wordt genegeerd.} other {<b>{tabs} vastgemaakte</b> tabbladen worden genegeerd.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Helder",
-    "note": "Button text to start data clearing."
+    "title": "Verwijderen",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Annuleren",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Hiermee worden je zoekinstellingen gereset.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Meer informatie",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Selecteer een periode om de geschiedenis te wissen.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Om ook de geschiedenis te verwijderen, selecteer je een tijdsperiode.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/pl/firebutton.json
+++ b/shared/locales/pl/firebutton.json
@@ -10,103 +10,111 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Zamknij karty i wyczyść dane",
+    "title": "Zamknij karty i usuń dane",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Wyczyść dane",
+    "title": "Usuń dane",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Tylko bieżąca strona",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Ostatnia godzina",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Ostatnie 24 godziny",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Ostatnie 7 dni",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Ostatnie 4 tygodnie",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Cały czas",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {jedna godzina} day {24 godziny} week {jeden tydzień} month {4 tygodnie} other {Wszystko}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Zamknąć <b>{openTabs}</b> zakładkę wyczyścić <b>{durationDesc}</b> historię przeglądania i pliki cookie?} few {Zamknąć <b>{openTabs}</b> zakładki i wyczyścić <b>{durationDesc}</b> historię przeglądania i pliki cookie?} many {Zamknąć <b>{openTabs}</b> zakładek i wyczyścić <b>{durationDesc}</b> historię przeglądania i pliki cookie?} other {Zamknąć <b>{openTabs}</b> zakładki i wyczyścić <b>{durationDesc}</b> historię przeglądania i pliki cookie?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Zamknąć <b>{openTabs}</b> kartę i usunąć historię przeglądania oraz pliki cookie z okresu <b>{durationDesc}</b>?} few {Zamknąć <b>{openTabs}</b> karty i usunąć historię przeglądania oraz pliki cookie z okresu <b>{durationDesc}</b>?} many {Zamknąć <b>{openTabs}</b> kart i usunąć historię przeglądania oraz pliki cookie z okresu <b>{durationDesc}</b>?} other {Zamknąć <b>{openTabs}</b> karty i usunąć historię przeglądania oraz pliki cookie z okresu <b>{durationDesc}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Zamknąć <b>{openTabs}</b> kartę i wyczyścić <b>{durationDesc}</b> plików cookie?} few {Zamknąć <b>{openTabs}</b> karty i wyczyścić <b>{durationDesc}</b> plików cookie?} many {Zamknąć <b>{openTabs}</b> kart i wyczyścić <b>{durationDesc}</b> plików cookie?} other {Zamknąć <b>{openTabs}</b> karty i wyczyścić <b>{durationDesc}</b> plików cookie?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Zamknąć <b>{openTabs}</b> kartę i usunąć pliki cookie z okresu <b>{durationDesc}</b>?} few {Zamknąć <b>{openTabs}</b> karty i usunąć pliki cookie z okresu <b>{durationDesc}</b>?} many {Zamknąć <b>{openTabs}</b> kart i usunąć pliki cookie z okresu <b>{durationDesc}</b>?} other {Zamknąć <b>{openTabs}</b> karty i usunąć pliki cookie z okresu <b>{durationDesc}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Wyczyścić <b>{durationDesc}</b> historii przeglądania i pliki cookie?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Usunąć historię przeglądania i pliki cookie z okresu <b>{durationDesc}</b>?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Wyczyścić <b>{durationDesc}</b> plików cookie?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Usunąć pliki cookie z okresu <b>{durationDesc}</b>?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Zamknij <b>{openTabs}</b> {openTabs, plural, =1 {kartę} other {kart(y)}} i wyczyść <b>całą</b> historię przeglądania i pliki cookie ({cookies} {cookies, plural, =1 {strony} other {str.}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Zamknąć <b>{openTabs}</b> {openTabs, plural, =1 {kartę} few {karty} many {kart} other {karty}} i usunąć <b>całą</b> historię przeglądania oraz wszystkie pliki cookie ({cookies} {cookies, plural, =1 {witryna} few {witryny} many {witryn} other {witryny}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Zamknij <b>{openTabs}</b> {openTabs, plural, =1 {kartę} other {kart(y)}}, i wyczyść <b>wszystkie</b> pliki cookie ({cookies} {cookies, plural, =1 {strony} other {str.}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Zamknąć <b>{openTabs}</b> {openTabs, plural, =1 {kartę} few {karty} many {kart} other {karty}} i usunąć <b>wszystkie</b> pliki cookie ({cookies} {cookies, plural, =1 {witryna} few {witryny} many {witryn} other {witryny}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Wyczyścić <b>całą</b> historię przeglądania i pliki cookie ({cookies} strony)?} few {Wyczyścić <b>całą</b> historię przeglądania i pliki cookie ({cookies} stron)?} many {Wyczyścić <b>całą</b> historię przeglądania i pliki cookie ({cookies} stron)?} other {Wyczyścić <b>całą</b> historię przeglądania i pliki cookie ({cookies} strony)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Usunąć <b>całą</b> historię przeglądania i wszystkie pliki cookie ({cookies} witryna)?} few {Usunąć <b>całą</b> historię przeglądania i wszystkie pliki cookie ({cookies} witryny)?} many {Usunąć <b>całą</b> historię przeglądania i wszystkie pliki cookie ({cookies} witryn)?} other {Usunąć <b>całą</b> historię przeglądania i wszystkie pliki cookie ({cookies} witryny)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Wyczyścić <b>wszystkie</b> pliki cookie ({cookies} strony)?} few {Wyczyścić <b>wszystkie</b> pliki cookie ({cookies} stron)?} many {Wyczyścić <b>wszystkie</b> pliki cookie ({cookies} stron)?} other {Wyczyścić <b>wszystkie</b> pliki cookie ({cookies} strony)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Usunąć <b>wszystkie</b> pliki cookie ({cookies} witryna)?} few {Usunąć <b>wszystkie</b> pliki cookie ({cookies} witryny)?} many {Usunąć <b>wszystkie</b> pliki cookie ({cookies} witryn)?} other {Usunąć <b>wszystkie</b> pliki cookie ({cookies} witryny)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Zamknąć <b>{openTabs} kartę {site}</b> i wyczyścić <b>wszystkie pliki cookie {site}</b>?} few {Zamknąć <b>{openTabs} karty {site}</b> i wyczyścić <b>wszystkie pliki cookie {site}</b>?} many {Zamknąć <b>{openTabs} kart {site}</b> i wyczyścić <b>wszystkie pliki cookie {site}</b>?} other {Zamknąć <b>{openTabs} karty {site}</b> i wyczyścić <b>wszystkie pliki cookie {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Zamknąć <b>{openTabs} kartę witryny {site}</b> i usunąć <b>wszystkie pliki cookie witryny {site}</b>?} few {Zamknąć <b>{openTabs} karty witryny {site}</b> i usunąć <b>wszystkie pliki cookie witryny {site}</b>?} many {Zamknąć <b>{openTabs} kart witryny {site}</b> i usunąć <b>wszystkie pliki cookie witryny {site}</b>?} other {Zamknąć <b>{openTabs} karty witryny {site}</b> i usunąć <b>wszystkie pliki cookie witryny {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Zamknąć <b>{openTabs} kartę {site}</b> i wyczyścić <b>wszystkie pliki cookie {site}</b>?} few {Zamknąć <b>{openTabs} karty {site}</b> i wyczyścić <b>wszystkie pliki cookie {site}</b>?} many {Zamknąć <b>{openTabs} kart {site}</b> i wyczyścić <b>wszystkie pliki cookie {site}</b>?} other {Zamknąć <b>{openTabs} karty {site}</b> i wyczyścić <b>wszystkie pliki cookie {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Zamknąć <b>{openTabs} kartę witryny {site}</b> i usunąć <b>wszystkie pliki cookie witryny {site}</b>?} few {Zamknąć <b>{openTabs} karty witryny {site}</b> i usunąć <b>wszystkie pliki cookie witryny {site}</b>?} many {Zamknąć <b>{openTabs} kart witryny {site}</b> i usunąć <b>wszystkie pliki cookie witryny {site}</b>?} other {Zamknąć <b>{openTabs} karty witryny {site}</b> i usunąć <b>wszystkie pliki cookie witryny {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Wyczyścić <b>całą historię przeglądania i pliki cookie {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Usunąć <b>całą historię przeglądania i wszystkie pliki cookie witryny {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Wyczyścić <b>wszystkie pliki cookie {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Usunąć <b>wszystkie pliki cookie witryny {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} przypięta karta</b> zostanie zignorowana.} few {<b>{tabs} przypięte karty</b> zostaną zignorowane.} many {<b>{tabs} przypiętych kart</b> zostanie zignorowanych.} other {<b>{tabs} przypiętej karty</b> zostanie zignorowane.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Wyczyść",
-    "note": "Button text to start data clearing."
+    "title": "Usuń",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Anuluj",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Spowoduje to zresetowanie ustawień wyszukiwania.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Dowiedz się więcej",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Aby wyczyścić również historię, wybierz okres.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Aby usunąć również historię, wybierz okres.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/pt/firebutton.json
+++ b/shared/locales/pt/firebutton.json
@@ -10,103 +10,111 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Fechar separadores e limpar os dados",
+    "title": "Fechar separadores e eliminar os dados",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Limpar dados",
+    "title": "Eliminar dados",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Só no site atual",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Última hora",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Últimas 24 horas",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Últimos 7 dias",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Últimas 4 semanas",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Sempre",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {uma hora} day {24 horas} week {uma semana} month {4 semanas} other {Todos}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Fechar <b>{openTabs}</b> separador e limpar <b>{durationDesc}</b> de histórico de navegação e cookies?} other {Fechar <b>{openTabs}</b> separadores e limpar <b>{durationDesc}</b> de histórico de navegação e cookies?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Fechar <b>{openTabs}</b> separador e eliminar <b>{durationDesc}</b> de histórico de navegação e cookies?} other {Fechar <b>{openTabs}</b> separadores e eliminar <b>{durationDesc}</b> de histórico de navegação e cookies?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Fechar <b>{openTabs}</b> separador e limpar <b>{durationDesc}</b> de cookies?} other {Close <b>{openTabs}</b> separadores e limpar <b>{durationDesc}</b> de cookies?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Fechar <b>{openTabs}</b> separador e eliminar <b>{durationDesc}</b> de cookies?} other {Close <b>{openTabs}</b> separadores e eliminar <b>{durationDesc}</b> de cookies?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Limpar <b>{durationDesc}</b> de histórico de navegação e cookies?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Apagar <b>{durationDesc}</b> de histórico de navegação e cookies?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Limpar <b>{durationDesc}</b> de cookies?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Eliminar <b>{durationDesc}</b> de cookies?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Fechar <b>{openTabs}</b> {openTabs, plural, =1 {separador} other {separadores}} e limpar <b>todo</b> o histórico de navegação e cookies ({cookies} {cookies, plural, =1 {site} other {sites}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Fechar <b>{openTabs}</b> {openTabs, plural, =1 {separador} other {separadores}}, e limpar <b>todo</b> o histórico de navegação e cookies ({cookies} {cookies, plural, =1 {site} other {sites}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Fechar <b>{openTabs}</b> {openTabs, plural, =1 {separador} other {separadores}} e limpar <b>todos</b> os cookies ({cookies} {cookies, plural, =1 {site} other {sites}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Fechar <b>{openTabs}</b> {openTabs, plural, =1 {separador} other {separadores}} e eliminar <b>todos</b> os cookies ({cookies} {cookies, plural, =1 {site} other {sites}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Limpar <b>todo</b> o histórico de navegação e cookies ({cookies} site)?} other {Limpar <b>todo</b> o histórico de navegação e cookies ({cookies} sites)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Apagar <b>todo</b> o histórico de navegação e cookies ({cookies} site)?} other {Apagar <b>todo</b> o histórico de navegação e cookies ({cookies} sites)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Limpar <b>todos</b> os cookies ({cookies} site)?} other {Limpar <b>todos</b> os cookies ({cookies} sites)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Apagar <b>todos</b> os cookies ({cookies} site)?} other {Apagar <b>todos</b> os cookies ({cookies} sites)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Fechar <b>{openTabs} separador em {site}</b> e limpar <b>todos os cookies de {site}</b>?} other {Fechar <b>{openTabs} separadores em {site}</b> e limpar <b>todos os cookies de {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Fechar <b>{openTabs} separador em {site}</b> e eliminar <b>todos os cookies de {site}</b>?e} other {Fechar <b>{openTabs} separadores em {site}</b> e eliminar <b>todos os cookies de {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Fechar <b>{openTabs} separador em {site}</b> e limpar <b>todos os cookies de {site}</b>?} other {Fechar <b>{openTabs} separadores em {site}</b> e limpar <b>todos os cookies de {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Fecha <b>{openTabs} </b> separador de <b>{site}</b> e elimina todos os cookies de {site}?} other {Fechar <b>{openTabs} separadores em {site}</b> e eliminar <b>todos os cookies de {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Limpar todo o histórico de navegação e cookies de <b>{site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Apagar todo o histórico de navegação e cookies de <b>{site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Limpar todos os cookies de <b>{site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Apagar <b>todos os cookies de {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} separador afixado</b> será ignorado.} other {<b>{tabs} separadores afixados</b> serão ignorados.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Céu limpo",
-    "note": "Button text to start data clearing."
+    "title": "Eliminar",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Cancelar",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Isto irá repor as tuas definições de pesquisa.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Saiba mais",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Para limpar o histórico, selecione um intervalo de tempo.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Para também apagar o histórico, selecione um intervalo de tempo.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/ro/firebutton.json
+++ b/shared/locales/ro/firebutton.json
@@ -14,99 +14,107 @@
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Ștergere date",
+    "title": "Șterge datele",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Numai de site-ul curent",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Ultima oră",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Ultimele 24 de ore",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Ultimele 7 zile",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Ultimele 4 săptămâni",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Totdeauna",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {o oră} day {24 de ore} week {o săptămână} month {4 săptămâni} other {Toate}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Închizi <b>{openTabs}</b> filă și ștergi istoricul de navigare și modulele cookie pentru <b>{durationDesc}</b>?} few {Închizi <b>{openTabs}</b> file și ștergi istoricul de navigare și modulele cookie pentru <b>{durationDesc}</b>?} other {Închizi <b>{openTabs}</b> de file și ștergi istoricul de navigare și modulele cookie pentru <b>{durationDesc}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Închizi <b>{openTabs}</b> filă și ștergi <b>{durationDesc}</b> din istoricul de navigare și modulele cookie?} few {Închizi <b>{openTabs}</b> file și ștergi <b>{durationDesc}</b> din istoricul de navigare și modulele cookie?} other {Închizi <b>{openTabs}</b> de file și ștergi <b>{durationDesc}</b> din istoricul de navigare și modulele cookie?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Închizi <b>{openTabs}</b> filă și ștergi modulele cookie pentru <b>{durationDesc}</b>?} few {Închizi <b>{openTabs}</b> file și ștergi modulele cookie pentru <b>{durationDesc}</b>?} other {Închizi <b>{openTabs}</b> de file și ștergi modulele cookie pentru <b>{durationDesc}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Închizi <b>{openTabs}</b> filă și ștergi <b>{durationDesc}</b> de module cookie?} few {Închizi <b>{openTabs}</b> file și ștergi <b>{durationDesc}</b> de module cookie?} other {Închizi <b>{openTabs}</b> de file și ștergi <b>{durationDesc}</b> de module cookie?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
     "title": "Ștergi istoricul de navigare și modulele cookie pentru <b>{durationDesc}</b>?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Ștergi modulele cookie pentru <b>{durationDesc}</b>?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Ștergi <b>{durationDesc}</b> de module cookie?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Închizi <b>{openTabs}</b> {openTabs, plural, =1 {tab} other {tabs}} și ștergi <b>întregul</b> istoric de navigare și toate modulele cookie ({cookies} {cookies, plural, =1 {site} other {sites}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Închizi <b>{openTabs}</b> {openTabs, plural, =1 {filă} other {file}} și ștergi <b>întregul</b> istoric de navigare și toate modulele cookie ({cookies} {cookies, plural, =1 {site} other {site-uri}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
     "title": "Închizi <b>{openTabs}</b> {openTabs, plural, =1 {filă} other {file}} și ștergi <b>toate</b> modulele cookie ({cookies} {cookies, plural, =1 {site} other {site-uri}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Ștergi <b>întregul</b> istoric de navigare și toate modulele cookie ({cookies} site)?} few {Ștergi <b>întregul</b> istoric de navigare și toate modulele cookie ({cookies} site-uri)?} other {Ștergi <b>întregul</b> istoric de navigare și toate modulele cookie ({cookies} de site-uri)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Ștergi <b>tot</b> istoricul de navigare și modulele cookie ({cookies} site)?} few {Ștergi <b>tot</b> istoricul de navigare și modulele cookie ({cookies} site-uri)?} other {Ștergi <b>tot</b> istoricul de navigare și cookie-urile ({cookies} de site-uri)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
     "title": "{cookies, plural, one {Ștergi <b>toate</b> modulele cookie ({cookies} site)?} few {Ștergi <b>toate</b> modulele cookie ({cookies} site-uri)?} other {Ștergi <b>toate</b> modulele cookie ({cookies} de site-uri)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Închizi <b>{openTabs} filă {site}</b> și ștergi <b>toate modulele cookie {site}</b>?} few {Închizi <b>{openTabs} file {site}</b> și ștergi <b>toate modulele cookie {site}</b>?} other {Închizi <b>{openTabs} de file {site}</b> și ștergi <b>toate modulele cookie {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Închizi <b>{openTabs} {site}</b> filă și ștergi <b>toate {site}</b> modulele cookie?} few {Închizi <b>{openTabs} {site}</b> file și ștergi <b>toate {site}</b> modulele cookie?} other {Închizi <b>{openTabs} {site}</b> de file și ștergi <b>toate {site}</b> modulele cookie?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Închizi <b>{openTabs} filă {site}</b> și ștergi <b>toate modulele cookie {site}</b>?} few {Închizi <b>{openTabs} file {site}</b> și ștergi <b>toate modulele cookie {site}</b>?} other {Închizi <b>{openTabs} file {site}</b> și ștergi <b>toate modulele cookie {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Închizi <b>{openTabs} filă {site}</b> și ștergi <b>toate modulele cookie {site}</b>?} few {Închizi <b>{openTabs} {site}</b> file și ștergi <b>toate {site}</b> modulele cookie?} other {Închizi <b>{openTabs} {site}</b> de file și ștergi <b>toate {site}</b> modulele cookie?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Ștergi întregul istoric de navigare și modulele cookie aferente <b>{site}</b> ?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Ștergi <b>tot istoricul {site}de navigare</b> și modulele cookie?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Ștergi toate modulele cookie aferente <b>{site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Ștergi <b>toate modulele cookie {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} filă fixată</b> va fi ignorată.} few {<b>{tabs} file fixate</b> vor fi ignorate.} other {<b>{tabs} de file fixate</b> vor fi ignorate.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Cer senin",
-    "note": "Button text to start data clearing."
+    "title": "Ștergere",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
-    "title": "Anulează",
+    "title": "Renunță",
     "note": "Button text to exit the fire button modal."
+  },
+  "clearingCookiesWarning": {
+    "title": "Aceasta va reseta setările de căutare.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Află mai multe",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
   },
   "historyAndDownloadsNotAffected": {
     "title": "Pentru a șterge și istoricul, selectează o perioadă.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/ru/firebutton.json
+++ b/shared/locales/ru/firebutton.json
@@ -14,99 +14,107 @@
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Сбросить данные",
+    "title": "Удалить данные",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Только с текущего сайта",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "За последний час",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "За последние 24 часа",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "За последние 7 дней",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "За последние 4 недели",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "За всё время",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
-    "title": "{duration, select, hour {за последний час} day {за последние 24 часа} week {за последнюю неделю} month {за последние 4 недели} other {Все}}",
+    "title": "{duration, select, hour {за последний час} day {за последние 24 часа} week {за последнюю неделю} month {за последние 4 недели} other {все}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Закрыть <b>{openTabs}</b> вкладку и удалить историю просмотров и куки-файлы <b>{durationDesc}</b>?} few {Закрыть <b>{openTabs}</b> вкладки и удалить историю просмотров и куки-файлы <b>{durationDesc}</b>?} many {Закрыть <b>{openTabs}</b> вкладок и удалить историю просмотров и куки-файлы <b>{durationDesc}</b>?} other {Закрыть вкладки (<b>{openTabs}</b>) и удалить историю просмотров и куки-файлы <b>{durationDesc}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Закрыть <b>{openTabs}</b> вкладку и удалить историю просмотров и куки-файлы (<b>{durationDesc}</b>)?} few {Закрыть <b>{openTabs}</b> вкладки и удалить историю просмотров и куки-файлы (<b>{durationDesc}</b>)?} many {Закрыть <b>{openTabs}</b> вкладок и удалить историю просмотров и куки-файлы (<b>{durationDesc}</b>)?} other {Закрыть вкладки (<b>{openTabs}</b>) и удалить историю просмотров и куки-файлы (<b>{durationDesc}</b>)?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Закрыть <b>{openTabs}</b> вкладку и удалить куки-файлы <b>{durationDesc}</b>?} few {Закрыть <b>{openTabs}</b> вкладки и удалить куки-файлы <b>{durationDesc}</b>?} many {Закрыть <b>{openTabs}</b> вкладок и удалить куки-файлы <b>{durationDesc}</b>?} other {Закрыть вкладки (<b>{openTabs}</b>) и удалить куки-файлы <b>{durationDesc}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Закрыть <b>{openTabs}</b> вкладку и удалить куки-файлы (<b>{durationDesc}</b>)?} few {Закрыть <b>{openTabs}</b> вкладки и удалить куки-файлы (<b>{durationDesc}</b>)?} many {Закрыть <b>{openTabs}</b> вкладок и удалить куки-файлы (<b>{durationDesc}</b>)?} other {Закрыть вкладки (<b>{openTabs}</b>) и удалить куки-файлы (<b>{durationDesc}</b>)?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Удалить историю просмотров и куки-файлы <b>{durationDesc}</b>?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Удалить историю просмотров и куки-файлы (<b>{durationDesc}</b>)?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Удалить куки-файлы <b>{durationDesc}</b>?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Удалить куки-файлы (<b>{durationDesc}</b>)?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Закрыть <b>{openTabs}</b> {openTabs, plural, =1 {вкладку} other {вклад.}} и удалить <b>всю</b> историю просмотров и куки-файлы (с {cookies} {cookies, plural, =1 {сайта} other {сайтов}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Закрыть <b>{openTabs}</b> {openTabs, plural, =1 {вкладку} other {вклад.}} и удалить <b>всю</b> историю просмотров и куки-файлы ({cookies} {cookies, plural, =1 {сайт} other {сайт.}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Закрыть <b>{openTabs}</b> {openTabs, plural, =1 {вкладку} other {вклад.}} и удалить <b>все</b> куки-файлы (с {cookies} {cookies, plural, =1 {сайта} other {сайтов}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Закрыть <b>{openTabs}</b> {openTabs, plural, =1 {вкладку} other {вклад.}} и удалить <b>все</b> куки-файлы ({cookies} {cookies, plural, =1 {сайт} other {сайт.}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Удалить <b>всю</b> историю просмотров и куки-файлы (с {cookies} сайта)?} few {Удалить <b>всю</b> историю просмотров и куки-файлы (с {cookies} сайтов)?} many {Удалить <b>всю</b> историю просмотров и куки-файлы (с {cookies} сайтов)?} other {Удалить <b>всю</b> историю просмотров и куки-файлы (с {cookies} сайтов)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Удалить <b>всю</b> историю просмотров и куки-файлы ({cookies} сайт)?} few {Удалить <b>всю</b> историю просмотров и куки-файлы ({cookies} сайта)?} many {Удалить <b>всю</b> историю просмотров и куки-файлы ({cookies} сайтов)?} other {Удалить <b>всю</b> историю просмотров и куки-файлы ({cookies} сайта)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Удалить <b>все</b> куки-файлы (с {cookies} сайта)?} few {Удалить <b>все</b> куки-файлы (с {cookies} сайтов)?} many {Удалить <b>все</b> куки-файлы (с {cookies} сайтов)?} other {Удалить <b>все</b> куки-файлы (с {cookies} сайтов)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Удалить <b>все</b> куки-файлы ({cookies} сайт)?} few {Удалить <b>все</b> куки-файлы ({cookies} сайта)?} many {Удалить <b>все</b> куки-файлы ({cookies} сайтов)?} other {Удалить <b>все</b> куки-файлы ({cookies} сайта)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Закрыть <b>{openTabs} вкладку {site}</b> и удалить <b>все куки-файлы с {site}</b>?} few {Закрыть <b>{openTabs} вкладки {site}</b> и удалить <b>все куки-файлы с {site}</b>?} many {Закрыть <b>{openTabs} вкладок {site}</b> и удалить <b>все куки-файлы с {site}</b>?} other {Закрыть <b>вкладки {site} ({openTabs})</b> и удалить <b>все куки-файлы с {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Закрыть <b>{openTabs} вкладку {site}</b> и удалить <b>все куки-файлы с {site}</b>?} few {Закрыть <b>{openTabs} вкладки {site}</b> и удалить <b>все куки-файлы с {site}</b>?} many {Закрыть <b>{openTabs} вкладок {site}</b> и удалить <b>все куки-файлы с {site}</b>?} other {Закрыть <b>{openTabs} вкладки {site}</b> и удалить <b>все куки-файлы с {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Закрыть <b>{openTabs} вкладку {site}</b> и удалить <b>все куки-файлы с {site}</b>?} few {Закрыть <b>{openTabs} вкладки {site}</b> и удалить <b>все куки-файлы с {site}</b>?} many {Закрыть <b>{openTabs} вкладок {site}</b> и удалить <b>все куки-файлы с {site}</b>?} other {Закрыть <b>вкладки {site} ({openTabs})</b> и удалить <b>все куки-файлы с {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Закрыть <b>{openTabs} вкладку {site}</b> и удалить <b>все куки-файлы с {site}</b>?} few {Закрыть <b>{openTabs} вкладки {site}</b> и удалить <b>все куки-файлы с {site}</b>?} many {Закрыть <b>{openTabs} вкладок {site}</b> и удалить <b>все куки-файлы с {site}</b>?} other {Закрыть <b>{openTabs} вкладки {site}</b> и удалить <b>все куки-файлы с {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
     "title": "Удалить <b>всю</b> историю просмотров и куки-файлы с {site}?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
     "title": "Удалить <b>все</b> куки-файлы с {site}?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} закрепленная</b> вкладка будет проигнорирована.} few {<b>{tabs} закрепленные</b> вкладки будут проигнорированы.} many {<b>{tabs} закрепленных</b> вкладок будет проигнорировано.} other {Закрепленные вкладки (<b>{tabs}</b>) будут проигнорированы.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Очистить",
-    "note": "Button text to start data clearing."
+    "title": "Удалить",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Отменить",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Поисковые настройки будут сброшены.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Узнать больше",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Если вы также хотите очистить историю, выберите временной отрезок.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Чтобы также очистить историю, выберите временной отрезок.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/sk/firebutton.json
+++ b/shared/locales/sk/firebutton.json
@@ -10,103 +10,111 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Zatvoriť karty a vymazať údaje",
+    "title": "Zatvoriť karty a odstrániť údaje",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Vymazať údaje",
+    "title": "Zmazať údaje",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Len aktuálna stránka",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Posledná hodina",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Posledných 24 hodín",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Posledných 7 dní",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Posledné 4 týždne",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Celé obdobie",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {jednu hodinu} day {24 hodín} week {jeden týždeň} month {4 týždne} other {Všetky}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Zatvoriť <b>{openTabs}</b> kartu a vymazať <b>{durationDesc}</b> histórie prehliadania a súbory cookie?} few {Zatvoriť <b>{openTabs}</b> karty a vymazať <b>{durationDesc}</b> histórie prehliadania a súbory cookie?} many {Zatvoriť <b>{openTabs}</b> karty a vymazať <b>{durationDesc}</b> histórie prehliadania a súbory cookie?} other {Zatvoriť <b>{openTabs}</b> kariet a vymazať <b>{durationDesc}</b> histórie prehliadania a súbory cookie?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Chceš zatvoriť <b>{openTabs}</b> kartu a odstrániť <b>{durationDesc}</b> histórie prehliadania a súborov cookie?} few {Chceš zatvoriť <b>{openTabs}</b> karty a odstrániť <b>{durationDesc}</b> históriu prehliadania a súbory cookie?} many {Chceš zatvoriť <b>{openTabs}</b> kariet a odstrániť <b>{durationDesc}</b> históriu prehliadania a súbory cookie?} other {Chceš zatvoriť <b>{openTabs}</b> kariet a odstrániť <b>{durationDesc}</b> histórie prehliadania a súborov cookie?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Zavrieť <b>{openTabs}</b> kartu a vymazať <b>{durationDesc}</b> súborov cookie?} few {Zavrieť <b>{openTabs}</b> karty a vymazať <b>{durationDesc}</b> súborov cookie?} many {Zavrieť <b>{openTabs}</b> karty a vymazať <b>{durationDesc}</b> súborov cookie?} other {Zavrieť <b>{openTabs}</b> kariet a vymazať <b>{durationDesc}</b> súborov cookie?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Chcete zatvoriť <b>{openTabs}</b> kartu a vymazať <b>{durationDesc}</b> súbory cookie?} few {Chcete zatvoriť <b>{openTabs}</b> karty a vymazať <b>{durationDesc}</b> súbory cookie?} many {Chcete zatvoriť <b>{openTabs}</b> kariet a vymazať <b>{durationDesc}</b> súbory cookie?} other {Chcete zatvoriť <b>{openTabs}</b> kariet a vymazať <b>{durationDesc}</b> súbory cookie?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Vymazať <b>{durationDesc}</b> histórie prehliadania a súborov cookie?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Chcete vymazať <b>{durationDesc}</b> histórie prehliadania a súborov cookie?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Vymazať <b>{durationDesc}</b> súborov cookie?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Chceš odstrániť súbory cookie za <b>{durationDesc}</b>?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Zatvoriť <b>{openTabs}</b> {openTabs, plural, =1 {kartu} other {kariet}} a vymazať <b>celú</b> históriu prehliadania a súbory cookie ({cookies} {cookies, plural, =1 {stránka} other {stránok}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Chcete zatvoriť <b>{openTabs}</b> {openTabs, plural, =1 {kartu} other {kariet}} a vymazať <b>celú</b> históriu prehliadania a súbory cookie ({cookie} {cookie, plural, =1 {lokalitu} other {lokality}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Zatvoriť <b>{openTabs}</b> {openTabs, plural, =1 {kartu} other {kariet}} a vymazať <b>všetky</b> súbory cookie ({cookies} {cookies, plural, =1 {stránku} other {stránok}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Chceš zatvoriť <b>{openTabs}</b> {openTabs, plural, =1 {kartu} other {kariet}} a vymazať <b>všetky</b> súbory cookie ({cookies} {cookies, plural, =1 {stránku} other {stránok}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Vymazať <b>celú</b> históriu prehliadania a súbory cookie ({cookies} stránka)?} few {Vymazať <b>celú</b> históriu prehliadania a súbory cookie ({cookies} stránky)?} many {Vymazať <b>celú</b> históriu prehliadania a súbory cookie ({cookies} stránky)?} other {Vymazať <b>celú</b> históriu prehliadania a súbory cookie ({cookies} stránok)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Chcete vymazať <b>celú</b> históriu prehliadania a súbory cookie pre ({cookies} lokalitu)?} few {Chcete vymazať <b>celú</b> históriu prehliadania a súbory cookie pre ({cookies} lokalít)?} many {Chcete vymazať <b>celú</b> históriu prehliadania a súbory cookie pre ({cookies} lokalít)?} other {Chcete vymazať <b>celú</b> históriu prehliadania a súbory cookie pre ({cookies} lokalít)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Vymazať <b>všetky</b> súbory cookie ({cookies} stránka)?} few {Vymazať <b>všetky</b> súbory cookie ({cookies} stránky)?} many {Vymazať <b>všetky</b> súbory cookie ({cookies} stránky)?} other {Vymazať <b>všetky</b> súbory cookie ({cookies} stránok)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Chcete vymazať <b>všetky</b> súbory cookie pre ({cookies} lokalitu)?} few {Chcete vymazať <b>všetky</b> súbory cookie ({cookies} lokalít)?} many {Chcete vymazať <b>všetky</b> súbory cookie ({cookies} lokalít)?} other {Chcete vymazať <b>všetky</b> súbory cookie ({cookies} lokalít)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Zatvoriť <b>{openTabs} kariet na stránke {site}</b> a vymazať <b>všetky súbory cookie zo stránky {site}</b> ?} few {Zatvoriť <b>{openTabs} karty na stránke {site}</b> a vymazať <b>všetky súbory cookie zo stránky {site}</b>?} many {Zatvoriť <b>{openTabs} karty na stránke {site}</b> a vymazať <b>všetky súbory cookie zo stránky {site}</b> ?} other {Zatvoriť <b>{openTabs} kariet {site}</b> a vymazať <b>všetky súbory cookie zo stránky {site}</b> ?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Chcete zatvoriť <b>{openTabs} kartu na stránke {site}</b> a vymazať <b>všetky súbory cookie pre lokalitu {site}</b>?} few {Chcete zatvoriť <b>{openTabs} kariet na stránke {site}</b> a vymazať <b>všetky súbory cookie pre lokalitu {site}</b>?} many {Chcete zatvoriť <b>{openTabs} kariet na stránke {site}</b> a vymazať <b>všetky súbory cookie pre lokalitu {site}</b>?} other {Chcete zatvoriť <b>{openTabs} {site}</b> kariet a vymazať <b>všetky súbory cookie pre {site} lokalít</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Zatvoriť <b>{openTabs} kartu na stránke {site}</b> a vymazať <b>všetky súbory cookie zo stránky {site}</b> ?} few {Zatvoriť <b>{openTabs} karty na stránke {site}</b> a vymazať <b>všetky súbory cookie zo stránky {site}</b>?} many {Zatvoriť <b>{openTabs} karty na stránke {site}</b> a vymazať <b>všetky súbory cookie zo stránky {site}</b> ?} other {Zatvoriť <b>{openTabs} kariet na stránke {site}</b> a vymazať <b>všetky súbory cookie zo stránky {site}</b> ?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Chceš zatvoriť <b>{openTabs} kartu pre lokalitu {site}</b> a vymazať <b>všetky súbory cookie pre lokalitu {site}</b> ?} few {Chceš zatvoriť <b>{openTabs} kartu pre lokalitu {site}</b> a vymazať <b>všetky súbory cookie pre lokalitu {site}</b> ?} many {Chceš zatvoriť <b>{openTabs} kartu pre lokalitu {site}</b> a vymazať <b>všetky súbory cookie pre lokalitu {site}</b> ?} other {Chceš zatvoriť <b>{openTabs} kartu pre lokalitu {site}</b> a vymazať <b>všetky súbory cookie pre lokalitu {site}</b> ?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Vymazať <b>celú históriu prehliadania a súbory cookie na stránke {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Chcete vymazať celú históriu prehliadania a súbory cookie pre <b>lokalitu {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Vymazať <b>všetky súbory cookie na stránke {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Chcete vymazať všetky súbory cookie pre <b>lokalitu {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} pripnutá</b> karta bude ignorovaná.} few {<b>{tabs} pripnuté</b> karty budú ignorované.} many {<b>{tabs} pripnutej</b> karty bude ignorovaných.} other {<b>{tabs} pripnutých</b> kariet bude ignorovaných.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Jasno",
-    "note": "Button text to start data clearing."
+    "title": "Vymazať",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Zrušiť",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Týmto sa obnovia vaše nastavenia vyhľadávania.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Zistite viac",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Ak chcete vymazať aj históriu, vyberte obdobie.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Ak chceš odstrániť aj históriu, vyber časové obdobie.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/sk/firebutton.json
+++ b/shared/locales/sk/firebutton.json
@@ -62,7 +62,7 @@
     "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Chcete zatvoriť <b>{openTabs}</b> {openTabs, plural, =1 {kartu} other {kariet}} a vymazať <b>celú</b> históriu prehliadania a súbory cookie ({cookie} {cookie, plural, =1 {lokalitu} other {lokality}})?",
+    "title": "Chcete zatvoriť <b>{openTabs}</b> {openTabs, plural, =1 {kartu} other {kariet}} a vymazať <b>celú</b> históriu prehliadania a súbory cookie ({cookies} {cookies, plural, =1 {lokalitu} other {lokality}})?",
     "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {

--- a/shared/locales/sl/firebutton.json
+++ b/shared/locales/sl/firebutton.json
@@ -14,99 +14,107 @@
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Počisti podatke",
+    "title": "Brisanje podatkov",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Samo trenutna stran",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Zadnja ura",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Zadnjih 24 ur",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Zadnjih 7 dni",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Zadnje 4 tedne",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Ves čas",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {ene ure} day {24 ur} week {enega tedna} month {4 tednov} other {Vse}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Želite zapreti <b>{openTabs}</b> zavihek ter počistiti zgodovino brskanja in piškotke za obdobje <b>{durationDesc}</b>?} two {Želite zapreti <b>{openTabs}</b> zavihka ter počistiti zgodovino brskanja in piškotke za obdobje <b>{durationDesc}</b>?} few {Želite zapreti <b>{openTabs}</b> zavihke ter počistiti zgodovino brskanja in piškotke za obdobje <b>{durationDesc}</b>?} other {Želite zapreti <b>{openTabs}</b> zavihkov ter počistiti zgodovino brskanja in piškotke za obdobje <b>{durationDesc}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Želite zapreti <b>{openTabs}</b> zavihek in izbrisati <b>{durationDesc}</b> zgodovine brskanja in piškotkov?} two {Želite zapreti <b>{openTabs}</b> zavihka in izbrisati <b>{durationDesc}</b> zgodovine brskanja in piškotkov?} few {Želite zapreti <b>{openTabs}</b> zavihke in izbrisati <b>{durationDesc}</b> zgodovine brskanja in piškotkov?} other {Želite zapreti <b>{openTabs}</b> zavihkov in izbrišite <b>{durationDesc}</b> zgodovine brskanja in piškotkov?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Želite zapreti <b>{openTabs}</b> zavihek in počistiti piškotke za obdobje <b>{durationDesc}</b>?} two {Želite zapreti <b>{openTabs}</b> zavihka in počistiti piškotke za obdobje <b>{durationDesc}</b>?} few {Želite zapreti <b>{openTabs}</b> zavihke in počistiti piškotke za obdobje <b>{durationDesc}</b>?} other {Želite zapreti <b>{openTabs}</b> zavihkov in počistiti piškotke za obdobje <b>{durationDesc}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Želite zapreti <b>{openTabs}</b> zavihek in izbrisati <b>{durationDesc}</b> piškotkov?} two {Želite zapreti <b>{openTabs}</b> zavihka in izbrisati <b>{durationDesc}</b> piškotkov?} few {Želite zapreti <b>{openTabs}</b> zavihke in izbrisati <b>{durationDesc}</b> piškotkov?} other {Želite zapreti <b>{openTabs}</b> zavihkov in izbrisati <b>{durationDesc}</b> piškotkov?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Želite počistiti zgodovino brskanja in piškotke za obdobje <b>{durationDesc}</b>?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Želite izbrisati zgodovino brskanja in piškotke za obdobje <b>{durationDesc}</b>?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Želite počistiti piškotke za obdobje <b>{durationDesc}</b>?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Želite izbrisati <b>{durationDesc}</b> piškotkov?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
     "title": "Želite zapreti <b>{openTabs}</b> {openTabs, plural, =1 {zavihek} other {zavihka/-e/-ov}} ter počistiti <b>vso</b> zgodovino brskanja in piškotke ({cookies} {cookies, plural, =1 {spletnega mesta} other {spletnih mest}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
     "title": "Želite zapreti <b>{openTabs}</b> {openTabs, plural, =1 {zavihek} other {zavihka/-e/-ov}} in počistiti <b>vse</b> piškotke ({cookies} {cookies, plural, =1 {spletnega mesta} other {spletnih mest}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Želite izbrisati <b>vso</b> zgodovino brskanja in piškotke (za {cookies} spletno mesto)?} two {Želite izbrisati <b>vso</b> zgodovino brskanja in piškotke (za {cookies} spletni mesti)?} few {Želite izbrisati <b>vso</b> zgodovino brskanja in piškotke (za {cookies} spletna mesta)?} other {Želite izbrisati <b>vso</b> zgodovino brskanja in piškotke (za {cookies} spletnih mest)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Izbrisati <b>vso</b> zgodovino brskanja in piškotke ({cookies} spletno mesto)?} two {Izbrisati <b>vso</b> zgodovino brskanja in piškotke ({cookies} spletni mesti)?} few {Izbrisati <b>vso</b> zgodovino brskanja in piškotke ({cookies} spletna mesta)?} other {Izbrisati <b>vso</b> zgodovino brskanja in piškotke ({cookies} spletnih mest)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Želite počistiti <b>vse</b> piškotke (za {cookies} spletno mesto)?} two {Želite počistiti <b>vse</b> piškotke (za {cookies} spletni mesti)?} few {Želite počistiti <b>vse</b> piškotke (za {cookies} spletna mesta)?} other {Želite počistiti <b>vse</b> piškotke (za {cookies} spletnih mest)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Izbrisati <b>vse</b> piškotke ({cookies} spletno mesto)?} two {Izbrisati <b>vse</b> piškotke ({cookies} spletni mesti)?} few {Izbrisati <b>vse</b> piškotke ({cookies} spletna mesta)?} other {Izbrisati <b>vse</b> piškotke ({cookies} spletnih mest)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Želite zapreti <b>{openTabs} zavihek spletnega mesta {site}</b> in izbrisati <b>vse piškotke spletnega mesta {site}</b>?} two {Želite zapreti <b>{openTabs} zavihka spletnega mesta {site}</b> in izbrisati <b>vse piškotke spletnega mesta {site}</b>?} few {Želite zapreti <b>{openTabs} zavihke spletnega mesta {site}</b> in izbrisati <b>vse piškotke spletnega mesta {site}</b>?} other {Želite zapreti <b>{openTabs} zavihkov spletnega mesta {site}</b> in izbrisati <b>vse piškotke spletnega mesta {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Želite zapreti <b>{openTabs} {site}</b> zavihek in izbrisati <b>vse piškotke na {site}</b> ?} two {Želite zapreti <b>{openTabs} {site}</b> zavihka in izbrisati <b>vse piškotke na {site}</b>?} few {Želite zapreti <b>{openTabs} {site}</b> zavihke in izbrisati <b>vse piškotke na {site}</b> ?} other {Želite zapreti <b>{openTabs} {site}</b> zavihkov in izbrisati <b>vse piškotke na {site}</b> ?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Želite zapreti <b>{openTabs} zavihek spletnega mesta {site}</b> in izbrisati <b>vse piškotke spletnega mesta {site}</b>?} two {Želite zapreti <b>{openTabs} zavihka spletnega mesta {site}</b> in izbrisati <b>vse piškotke spletnega mesta {site}</b>?} few {Želite zapreti <b>{openTabs} zavihke spletnega mesta {site}</b> in izbrisati <b>vse piškotke spletnega mesta {site}</b>?} other {Želite zapreti <b>{openTabs} zavihkov spletnega mesta {site}</b> in izbrisati <b>vse piškotke spletnega mesta {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Želite zapreti <b>{openTabs} {site}</b> zavihke in izbrisati <b>vse piškotke na {site}</b>?} two {Želite zapreti <b>{openTabs} {site}</b> zavihkov in izbrisati <b>vse piškotke na {site}</b>?} few {Želite zapreti <b>{openTabs} {site}</b> zavihke in izbrisati <b>vse piškotke na {site}</b> ?} other {Želite zapreti <b>{openTabs} {site}</b> zavihkov in izbrisati <b>vse piškotke na {site}</b> ?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Želite izbrisati <b>vso zgodovino brskanja in piškotke za spletno mesto {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Želite izbrisati <b>vso {site}</b> zgodovino brskanja in piškotke?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Želite izbrisati <b>vse piškotke za spletno mesto {site}</b>)?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Želite izbrisati <b>vse piškotke {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} pripet</b> zavihek bo prezrt.} two {<b>{tabs} pripeta</b> zavihka bosta prezrta.} few {<b>{tabs} pripeti</b> zavihki bodo prezrti.} other {<b>{tabs} pripetih</b> zavihkov bo prezrtih.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Počisti",
-    "note": "Button text to start data clearing."
+    "title": "Izbriši",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
-    "title": "Preklic",
+    "title": "Prekliči",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "S tem boste ponastavili nastavitve iskanja.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Več",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Če želite počistiti tudi zgodovino, izberite časovno obdobje.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Če želite izbrisati tudi zgodovino, izberite časovno obdobje.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/sv/firebutton.json
+++ b/shared/locales/sv/firebutton.json
@@ -10,103 +10,111 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Stäng flikar och rensa data",
+    "title": "Stäng flikar och ta bort data",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Rensa data",
+    "title": "Radera data",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Endast nuvarande webbplats",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Senaste timmen",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Senaste 24 timmarna",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Senaste 7 dagarna",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Senaste 4 veckorna",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "För all tid",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {en timmes} day {24 timmars} week {en veckas} month {4 veckors} other {Alla}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {Vill du stänga <b>{openTabs}</b> flik och rensa <b>{durationDesc}</b> surfhistorik och cookies?} other {Vill du stänga <b>{openTabs}</b> flikar och rensa <b>{durationDesc}</b> surfhistorik och cookies?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {Vill du stänga <b>{openTabs}</b> flik och ta bort <b>{durationDesc}</b> surfhistorik och cookies?} other {Vill du stänga <b>{openTabs}</b> flikar och ta bort <b>{durationDesc}</b> surfhistorik och cookies?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
-    "title": "{openTabs, plural, one {Vill du stänga <b>{openTabs}</b> flik och rensa <b>{durationDesc}</b> cookies?} other {Vill du stänga <b>{openTabs}</b> flikar och rensa <b>{durationDesc}</b> cookies?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "title": "{openTabs, plural, one {Vill du stänga <b>{openTabs}</b> flik och ta bort <b>{durationDesc}</b> cookies?} other {Vill du ta bort <b>{openTabs}</b> flikar och ta bort <b>{durationDesc}</b> cookies?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
-    "title": "Vill du rensa <b>{durationDesc}</b> surfhistorik och cookies?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "title": "Vill du ta bort <b>{durationDesc}</b> surfhistorik och cookies?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "Vill du rensa <b>{durationDesc}</b> cookies?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "Vill du ta bort cookies för <b>{durationDesc}</b>?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "Vill du stänga <b>{openTabs}</b> {openTabs, plural, =1 {flik} other {flikar}}, rensa <b>all</b> surfhistorik och alla ({cookies} {cookies, plural, =1 {webbplats} other {webbplatser}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "Vill du stänga <b>{openTabs}</b> {openTabs, plural, =1 {flik} other {flikar}}, och ta bort <b>all</b> surfhistorik och cookies ({cookies} {cookies, plural, =1 {webbplats} other {webbplatser}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "Vill du stänga <b>{openTabs}</b> {openTabs, plural, =1 {flik} other {flikar}} och rensa <b>alla</b> cookies ({cookies} {cookies, plural, =1 {webbplats} other {webbplatser}})?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "Vill du stänga <b>{openTabs}</b> {openTabs, plural, =1 {flik} other {flikar}}, och ta bort <b>alla</b> cookies ({cookies} {cookies, plural, =1 {webbplats} other {webbplatser}})?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {Vill du rensa <b>all</b> surfhistorik och alla cookies ({cookies} webbplats)?} other {Vill du rensa <b>all</b> surfhistorik och alla cookies ({cookies} webbplatser)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {Vill du ta bort <b>all</b> surfhistorik och cookies ({cookies} webbplats)?} other {Vill du ta bort <b>all</b> surfhistorik och cookies ({cookies} webbplatser)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {Vill du rensa <b>alla</b> cookies ({cookies} webbplats)?} other {Vill du rensa <b>alla</b> cookies ({cookies} webbplatser)?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {Vill du ta bort <b>alla</b> cookies ({cookies} webbplats)?} other {Vill du ta bort <b>alla</b> cookies ({cookies} webbplatser)?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {Vill du stänga <b>{openTabs} flik för {site}</b> och rensa <b>alla cookies för {site}</b>?} other {Vill du stänga <b>{openTabs} flikar för {site}</b> och rensa <b>alla cookies för {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Vill du stänga <b>{openTabs} flik för {site}</b> och ta bort <b>alla cookies för {site}</b>?} other {Vill du stänga <b>{openTabs} flikar för {site}</b> och ta bort <b>alla cookies för {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {Vill du stänga <b>{openTabs} flik för {site}</b> och rensa <b>alla cookies för {site}</b>?} other {Vill du stänga <b>{openTabs} flikar för {site}</b> och rensa <b>alla cookies för {site}</b>?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {Vill du stänga <b>{openTabs} {site}</b> flik och ta bort <b>alla cookies för {site}</b>?} other {Vill du stänga <b>{openTabs} flikar för {site}</b> och ta bort <b>alla cookies för {site}</b>?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
-    "title": "Vill du rensa <b>all surfhistorik och alla cookies för {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "title": "Vill du ta bort <b>all surfhistorik och cookies för {site}</b> ?",
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
-    "title": "Vill du rensa <b>alla cookies för {site}</b>?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "title": "Vill du ta bort <b>alla cookies för {site}</b>?",
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} fäst</b> flik kommer att ignoreras.} other {<b>{tabs} fästa</b> flikar kommer att ignoreras.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Klart",
-    "note": "Button text to start data clearing."
+    "title": "Ta bort",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
     "title": "Avbryt",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Detta återställer dina sökinställningar.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Läs mer",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Om du också vill rensa historiken väljer du en tidsperiod.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Om du också vill ta bort historiken väljer du en tidsperiod.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/locales/tr/firebutton.json
+++ b/shared/locales/tr/firebutton.json
@@ -10,103 +10,111 @@
     ]
   },
   "fireDialogHeader": {
-    "title": "Sekmeleri Kapat ve Verileri Temizle",
+    "title": "Sekmeleri Kapat ve Verileri Sil",
     "note": "Dialog header."
   },
   "fireDialogHeaderNoTabs": {
-    "title": "Verileri Temizle",
+    "title": "Verileri Sil",
     "note": "Dialog header when tab clearing is disabled."
   },
   "optionCurrentSite": {
     "title": "Yalnızca mevcut site",
-    "note": "Dropdown option to only clear data for the current active website"
+    "note": "Dropdown option to only delete data for the current active website"
   },
   "optionLastHour": {
     "title": "Son bir saat",
-    "note": "Dropdown option to only clear data from the past hour"
+    "note": "Dropdown option to only delete data from the past hour"
   },
   "optionLast24Hour": {
     "title": "Son 24 saat",
-    "note": "Dropdown option to only clear data from the past 24 hours"
+    "note": "Dropdown option to only delete data from the past 24 hours"
   },
   "optionLast7days": {
     "title": "Son 7 gün",
-    "note": "Dropdown option to only clear data from the past 7 days"
+    "note": "Dropdown option to only delete data from the past 7 days"
   },
   "optionLast4Weeks": {
     "title": "Son 4 hafta",
-    "note": "Dropdown option to only clear data from the past 4 weeks"
+    "note": "Dropdown option to only delete data from the past 4 weeks"
   },
   "optionAllTime": {
     "title": "Her zaman",
-    "note": "Dropdown option to clear all data, since recording started"
+    "note": "Dropdown option to delete all data, since recording started"
   },
   "historyDuration": {
     "title": "{duration, select, hour {bir saat} day {24 saat} week {bir hafta} month {4 hafta} other {Tümü}}",
     "note": "Description of what period of history data should be deleted."
   },
   "summaryClearTabsHistoryDuration": {
-    "title": "{openTabs, plural, one {<b>{openTabs}</b> sekme kapatılsın ve <b>{durationDesc}</b> süreli tarama geçmişi ve çerezler temizlensin mi?} other {<b>{openTabs}</b> sekme kapatılsın ve <b>{durationDesc}</b> süreli tarama geçmişi ve çerez temizlensin mi?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of browsing…"
+    "title": "{openTabs, plural, one {<b>{openTabs}</b> sekme kapatılsın ve <b>{durationDesc}</b> süreli tarama geçmişi ve çerezler silinsin mi?} other {<b>{openTabs}</b> sekme kapatılsın ve <b>{durationDesc}</b> süreli tarama geçmişi ve çerezler silinsin mi?}}",
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of browsing…"
   },
   "summaryClearTabsDuration": {
     "title": "{openTabs, plural, one {<b>{openTabs}</b> sekme kapatılsın ve <b>{durationDesc}</b> süreli çerez silinsin mi?} other {<b>{openTabs}</b> sekme kapatılsın ve <b>{durationDesc}</b> süreli çerez silinsin mi?}}",
-    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and clear 2 weeks of cookies?"
+    "note": "Description of data to be removed after the user submits the form. Placeholders stand for: 1. the number of tabs that will be affected; 2. the timespan of data to be removed (translated separately with key historyDuration). Example: Close 3 tabs and delete 2 weeks of cookies?"
   },
   "summaryClearHistoryDuration": {
     "title": "<b>{durationDesc}</b> süreli tarama geçmişi ve çerez silinsin mi?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of browsing…"
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of browsing…"
   },
   "summaryClearCookiesDuration": {
-    "title": "<b>{durationDesc}</b> süreli çerez temizlensin mi?",
-    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Clear 2 weeks of cookies?"
+    "title": "<b>{durationDesc}</b> süreli çerez silinsin mi?",
+    "note": "Description of data to be removed after the user submits the form. The placeholder stands for the timespan of data to be removed (translated separately with key historyDuration). Example: Delete 2 weeks of cookies?"
   },
   "summaryClearTabsHistoryAll": {
-    "title": "<b>{openTabs}</b> {openTabs, plural, =1 {sekme} other {sekme}} kapatılsın ve <b>tüm</b> tarama geçmişi ve çerezler ({cookies} {cookies, plural, =1 {site} other {site}}) temizlensin mi?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear browsing history and cookies (2 sites)?"
+    "title": "<b>{openTabs}</b> {openTabs, plural, =1 {sekme} other {sekme}} kapatılsın ve <b>tüm</b> tarama geçmişi ve çerezler ({cookies} {cookies, plural, =1 {site} other {site}}) silinsin mi?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete browsing history and cookies (2 sites)?"
   },
   "summaryClearTabsAll": {
-    "title": "<b>{openTabs}</b> {openTabs, plural, =1 {sekme} other {sekme}} kapatılsın ve <b>tüm</b> çerezler ({cookies} {cookies, plural, =1 {site} other {site}}) temizlensin mi?",
-    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll clear cookies. Example: Close 3 tabs, and clear all cookies (2 sites)?"
+    "title": "<b>{openTabs}</b> {openTabs, plural, =1 {sekme} other {sekme}} kapatılsın ve <b>tüm</b> çerezler ({cookies} {cookies, plural, =1 {site} other {site}}) silinsin mi?",
+    "note": "Description of data to be removed after the user submits the form. The placeholders are for the number of tabs to be closed, and the number of sites where we'll delete cookies. Example: Close 3 tabs, and delete all cookies (2 sites)?"
   },
   "summaryClearHistoryAll": {
-    "title": "{cookies, plural, one {<b>Tüm</b> tarama geçmişi ve çerezler ({cookies} site) temizlensin mi?} other {<b>Tüm</b> tarama geçmişi ve çerezler ({cookies} site) temizlensin mi?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all browsing history and cookies (2 sites)?"
+    "title": "{cookies, plural, one {<b>Tüm</b> tarama geçmişi ve çerezler ({cookies} site) silinsin mi?} other {<b>Tüm</b> tarama geçmişi ve çerezler ({cookies} site) silinsin mi?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all browsing history and cookies (2 sites)?"
   },
   "summaryClearCookiesAll": {
-    "title": "{cookies, plural, one {<b>Tüm</b> çerezler ({cookies} site) temizlensin mi?} other {<b>Tüm</b> çerezler ({cookies} site) temizlensin mi?}}",
-    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll clear cookies. Example: Clear all cookies (2 sites)?"
+    "title": "{cookies, plural, one {<b>Tüm</b> çerezler ({cookies} site) silinsin mi?} other {<b>Tüm</b> çerezler ({cookies} site) silinsin mi?}}",
+    "note": "Description of data to be removed after the user submits the form. The placeholders stand for the number of sites where we'll delete cookies. Example: Delete all cookies (2 sites)?"
   },
   "summaryClearTabsHistorySite": {
-    "title": "{openTabs, plural, one {<b>{openTabs} {site}</b> sekmesi kapatılsın ve <b>tüm {site}</b> çerezleri temizlensin mi?} other {<b>{openTabs} {site}</b> sekmeleri kapatılsın ve <b>tüm {site}</b> çerezleri temizlensin mi?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {<b>{openTabs} {site}</b> sekmesi kapatılsın ve <b>tüm {site}</b> çerezleri silinsin mi?} other {<b>{openTabs} {site}</b> sekmeleri kapatılsın ve <b>tüm {site}</b> çerezleri silinsin mi?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearTabsSite": {
-    "title": "{openTabs, plural, one {<b>{openTabs} {site}</b> sekmesi kapatılsın ve <b>tüm {site}</b> çerezleri temizlensin mi?} other {<b>{openTabs} {site}</b> sekmeleri kapatılsın ve <b>tüm {site}</b> çerezleri temizlensin mi?}}",
-    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and clear <b>all example.com</b> cookies?\"."
+    "title": "{openTabs, plural, one {<b>{openTabs} {site}</b> sekmesi kapatılsın ve <b>tüm {site}</b> çerezleri silinsin mi?} other {<b>{openTabs} {site}</b> sekmeleri kapatılsın ve <b>tüm {site}</b> çerezleri silinsin mi?}}",
+    "note": "Description of data to be removed after the user submits the form. Example: \"Close <b>3 example.com</b> tabs, and delete <b>all example.com</b> cookies?\"."
   },
   "summaryClearHistorySite": {
     "title": "<b>Tüm {site}</b> tarama geçmişi ve çerezleri silinsin mi?",
-    "note": "Description of data to be removed after the user submits the form. Example: Clear all example.com browsing history and cookies?"
+    "note": "Description of data to be removed after the user submits the form. Example: Delete all example.com browsing history and cookies?"
   },
   "summaryClearCookiesSite": {
     "title": "<b>Tüm {site}</b> çerezleri silinsin mi?",
-    "note": "Description of data to be removed after the user submits the form. Clear all example.com cookies?"
+    "note": "Description of data to be removed after the user submits the form. Delete all example.com cookies?"
   },
   "summaryPinnedIgnored": {
     "title": "{tabs, plural, one {<b>{tabs} sabitlenmiş</b> sekme yoksayılacak.} other {<b>{tabs} sabitlenmiş</b> sekme yoksayılacak.}}",
     "note": "Notice to tell the user that some tabs will not be closed. Example: 3 pinned tabs will be ignored."
   },
   "clearData": {
-    "title": "Temizle",
-    "note": "Button text to start data clearing."
+    "title": "Sil",
+    "note": "Button text to start data deletion."
   },
   "cancel": {
-    "title": "Vazgeç",
+    "title": "İptal",
     "note": "Button text to exit the fire button modal."
   },
+  "clearingCookiesWarning": {
+    "title": "Bu işlem Arama ayarlarını sıfırlayacaktır.",
+    "note": "Warning message shown when deleting cookies, informing the user that their search settings will be reset."
+  },
+  "learnMore": {
+    "title": "Daha Fazla Bilgi",
+    "note": "Link text that opens a help page with more information about deleting cookies and search settings."
+  },
   "historyAndDownloadsNotAffected": {
-    "title": "Geçmişi de temizlemek için bir zaman aralığı seçin.",
-    "note": "Notice to tell the user that the chosen clearing settings will not affect history and downloads because a time period has not been selected from the dropdown."
+    "title": "Geçmişi de silmek için bir zaman aralığı seçin.",
+    "note": "Notice to tell the user that the chosen deletion settings will not affect history and downloads because a time period has not been selected from the dropdown."
   }
 }

--- a/shared/scss/_vars.scss
+++ b/shared/scss/_vars.scss
@@ -1,6 +1,6 @@
 $font__face--default: system, -apple-system, system-ui, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
     'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
-$font__face--browser-alt: 'DDG_ProximaNova';
+$font__face--browser-alt: 'DDG_ProximaNova', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
 
 /* Status icons */
 $status--good: 'refresh-assets/Check-Color-16.svg';

--- a/shared/scss/views/_fire-button.scss
+++ b/shared/scss/views/_fire-button.scss
@@ -119,6 +119,20 @@
     font-size: 15px;
 }
 
+#fire-button-summary .fire-button-learn-more {
+    color: #3969ef;
+    text-decoration: none;
+    cursor: pointer;
+
+    &:hover {
+        text-decoration: underline;
+    }
+
+    .body--theme-dark & {
+        color: #7295f6;
+    }
+}
+
 #fire-button-summary p {
     text-align: center;
     font-weight: 400;


### PR DESCRIPTION


<!-- Please add the WIP label if the PR isn't complete. -->

**Reviewer:**

<!-- Optional fields
**CC:**
**Depends on:**
-->

## Description:
Updated the fire dialog copy to replace "Clear" with "Delete" throughout (header, summary, button, disclaimers) per copywriting review. The cookie warning ("This will reset your Search settings. Learn More") is now scoped to only appear when the user is on duckduckgo.com with "Current site only" selected, as confirmed by the extensions team that only this scenario actually clears DDG settings.

## Steps to test this PR:

1. Run npm install && npm run build.debug && npm run preview
2. In the iframe view, scroll to the browser platform and click the fire icon in the search bar
3. Select the fire-button-ddg-site state — verify:

- The header says "Close Tabs and Delete Data"
- The summary uses "delete" instead of "clear"
- The warning "This will reset your Search settings." and "Learn More" link appear
- The button says "Delete"

8. Select the fire-button-ddg-time-based state — verify the cookie warning does not appear
9. Select the fire-button-no-pinned state (example.com) — verify the cookie warning does not appear even with "Current site only"
10. Run npx playwright test --grep "fire button" — all 8 tests should pass

<!-- Explain what is being changed, why, etc -->

## Screenshots
### *Note:* Please ignore the font difference, the local preview always use system font.
| # | Production | Change |
|---|---|---|
| Current Site Only - duckduckgo.com |<img width="341" height="333" alt="image" src="https://github.com/user-attachments/assets/638be317-9565-4ea9-8f8d-f88be4cae7bb" />|<img width="393" height="412" alt="image (15)" src="https://github.com/user-attachments/assets/17258beb-5a57-43c0-b53c-59435ac7514d" />|
| Current Site Only - Google.com| <img width="393" height="412" alt="Screenshot 2026-03-27 at 15 20 38" src="https://github.com/user-attachments/assets/66ef7e27-84d3-4cba-bbe7-4bd00ada5ecc" /> | <img width="393" height="412" alt="Screenshot 2026-03-27 at 15 22 35" src="https://github.com/user-attachments/assets/438d7902-710f-4b79-ba3f-9385b1d9b2ce" /> |
| Time based option |<img width="393" height="412" alt="Screenshot 2026-03-27 at 15 20 19" src="https://github.com/user-attachments/assets/38666cad-9059-4ea2-83af-527427f79451" />| <img width="338" height="299" alt="image" src="https://github.com/user-attachments/assets/c190e95a-216b-4f7a-903a-cfe56b7b9234" /> |








<!-- List steps to test it manually
1. <STEP 1>
-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/i18n updates plus a small conditional rendering change and new integration coverage; no sensitive logic or data handling changes.
> 
> **Overview**
> **Fire Button dialog wording is updated** to use “Delete” instead of “Clear” across the button, headers, summaries, and disclaimers via locale updates.
> 
> **When the selected burn option targets `duckduckgo.com`**, the dialog now appends a cookie/settings warning and a “Learn More” link to a new `duckDuckGoURLs.settingsHelpPage` constant.
> 
> Test fixtures and Playwright integration tests are extended with DDG/Google burn-option states and a new assertion that the warning/link appear only for the DDG current-site case.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6826e4d5d28ed990933ad173359c0c55e2672ba5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->