### PR TITLE
Fix iOS Privacy Dashboard scrolling and Done button on small screens

### DIFF
--- a/shared/scss/popup.scss
+++ b/shared/scss/popup.scss
@@ -49,7 +49,7 @@ body {
     // mobile environments
     &.environment--ios {
         --width: 100%;
-        --height: -webkit-fill-available;
+        --height: 100dvh;
     }
 
     &.environment--android {

--- a/shared/scss/views/_top-nav.scss
+++ b/shared/scss/views/_top-nav.scss
@@ -16,6 +16,10 @@ body {
     width: 100%;
     height: var(--nav-height);
     background: var(--page-bg);
+
+    .environment--ios & {
+        z-index: 10;
+    }
 }
 
 .top-nav__spacer {


### PR DESCRIPTION
**Reviewer:** @shakyShane 
**Asana Task:** https://app.asana.com/1/137249556945/project/414709148257752/task/1210936431926742?focus=true

## Description:

Two iOS-only fixes for the Privacy Dashboard on small screens (e.g. iPhone SE):

1. **Not scrollable** (`shared/scss/popup.scss`): the scroll container is sized from `--height`, which on iOS was `-webkit-fill-available`. In the WKWebView the `#app` ancestor has no definite height, so `-webkit-fill-available` resolves to the *content* height rather than the viewport: the container grows to fit all of its content and never scrolls, and `body { overflow: hidden }` clips the overflow, leaving content below the fold unreachable. Switched `--height` to `100dvh`, which resolves to the visible viewport regardless of the ancestor chain, so `overflow-y: auto` scrolls as intended (and it tracks the visible area when the keyboard is shown).

2. **Done button not tappable** (`shared/scss/views/_top-nav.scss`) — the fixed header used `z-index: 1`, which tied with `.page-inner` (also `z-index: 1`) and lost on DOM order, so scrolling content and the tracker "key insight" circles (`z-index: 2–4`) painted over the header and intercepted taps on Done. Added a `z-index: 10` override scoped to `.environment--ios` (the navigation-chrome tier, matching `.main-nav__item`), above content (0–4) and below the fire-button overlay (100). The base `.top-nav` rule is unchanged at `z-index: 1`.

## Steps to test this PR:

1. `npm ci && npm run build`.
2. Point an iOS build at this checkout (workspace-local SwiftPM package, or `.package(path:)` in BrowserServicesKit) and clean-build.
3. On an iPhone SE, open the Privacy Dashboard on a tracker-heavy site so its content is taller than the screen.
4. **Scrolling:** the dashboard scrolls and all content below the fold is reachable (before: clipped and unscrollable).
5. **Done button:** tappable in both portrait and landscape, including where the tracker circles sit near the header (before: content painted over it and swallowed the tap).

<details>
<summary>Video (after)</summary>

simulator: 
https://github.com/user-attachments/assets/3a4f0ea3-7a69-4211-8132-c747a0f7c524

iOS (real device)

https://github.com/user-attachments/assets/e2884eeb-ead7-4528-a2af-51bfaedbbe35


iPad (real device)

https://github.com/user-attachments/assets/3822cd95-357f-4e7c-b85a-474c9bbd1f01


</details>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped iOS CSS variable and z-index overrides with no auth, data, or shared non-iOS behavior changes.
> 
> **Overview**
> Fixes two **iOS-only** layout issues on small screens (e.g. iPhone SE) in the Privacy Dashboard.
> 
> On iOS, the popup `--height` custom property is changed from `-webkit-fill-available` to **`100dvh`** so the scroll container gets a viewport-sized height in WKWebView (where fill-available could match content height and prevent scrolling while `overflow: hidden` on `body` clips unreachable content).
> 
> The fixed **top nav** gets **`z-index: 10`** under `.environment--ios` so the Done/back chrome stays above dashboard content and tracker key-insight layers (`z-index` 2–4) that were intercepting taps, without changing the default `z-index: 1` on other platforms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c70c9dc85b0ae0e5c22fd5f328009213787f22d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->